### PR TITLE
Refactor boundary_detector and paragraph streamer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
   "loguru>=0.7.3,<1.0",
   "regex>=2025.7.29",
   "ftfy>=6.2.0,<7.0",
+  "sentinel>=1.0,<2.0",
   "pydantic>=2.12.2,<3.0",
 ]
 
@@ -63,6 +64,7 @@ build-backend = "setuptools.build_meta"
 package-dir = { "" = "src" }
 packages = [
     "yasbd",
+    "yasbd.utils",
     "yasbd.rules",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
   "loguru>=0.7.3,<1.0",
   "regex>=2025.7.29",
   "ftfy>=6.2.0,<7.0",
-  "sentinel>=1.0,<2.0",
   "pydantic>=2.12.2,<3.0",
 ]
 

--- a/src/yasbd/__init__.py
+++ b/src/yasbd/__init__.py
@@ -1,4 +1,3 @@
-from yasbd.boundary_detector import BoundaryDetector
-from yasbd.utils.pysbd_adapter import TextSpan
+from yasbd.boundary_detector import BoundaryDetector, ParagraphEOF
 
-__all__ = ["TextSpan", "BoundaryDetector"]
+__all__ = ["BoundaryDetector", "ParagraphEOF"]

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -8,7 +8,7 @@ from loguru import logger
 
 from yasbd.utils.cleaner_stub import StreamCleanerStub
 from yasbd.utils.input_validator import validate_input
-from yasbd.utils.paragraph_streamer import ParagraphStreamer
+from yasbd.utils.paragraph_stream import ParagraphStream
 
 ParagraphEOF = sentinel.create("ParagraphEOF")
 
@@ -120,9 +120,7 @@ class BoundaryDetector:
             )
 
         para_iter = (
-            ParagraphStreamer(source)
-            if isinstance(source, (str, TextIOBase))
-            else source
+            ParagraphStream(source) if isinstance(source, (str, TextIOBase)) else source
         )
 
         offset = 0
@@ -166,7 +164,7 @@ class BoundaryDetector:
             logger.info("Called with preserve_whitespace={}", preserve_whitespace)
 
         para_iter = (
-            ParagraphStreamer(source, skip_empty_lines=not preserve_whitespace)
+            ParagraphStream(source, skip_empty_lines=not preserve_whitespace)
             if isinstance(source, (str, TextIOBase))
             else source
         )

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -75,7 +75,6 @@ class BoundaryDetector:
         para_iter: Iterable[str],
     ) -> Generator[tuple[int, int], None, None]:
         """Yield per-paragraph sentence spans."""
-        offset = 0
         for para in para_iter:
             if not para.strip():
                 boundaries = [0, len(para)]
@@ -86,7 +85,6 @@ class BoundaryDetector:
                 start = boundaries[i]
                 end = boundaries[i + 1]
                 yield (start, end)
-            offset += len(para)
 
     @validate_input
     def detect(

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -115,9 +115,24 @@ class BoundaryDetector:
         Yields:
             ``(start_offset, end_offset)`` for each sentence.
         """
-        yield from self._rule.apply(
-            para_iter, self.preserve_quote_and_paren, relative=relative
-        )
+        offset = 0
+        for para in para_iter:
+            if not para.strip():
+                n = len(para)
+                yield (offset, offset + n) if not relative else (0, n)
+                if not relative:
+                    offset += n
+                continue
+
+            boundaries = self._rule.apply(para, self.preserve_quote_and_paren)
+
+            for i in range(len(boundaries) - 1):
+                start = boundaries[i]
+                end = boundaries[i + 1]
+                yield (offset + start, offset + end) if not relative else (start, end)
+
+            if not relative:
+                offset += len(para)
 
     @validate_input
     def segment(

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -126,16 +126,16 @@ class BoundaryDetector:
         offset = 0
         is_first_pos = True
         for para in para_iter:
+            if relative and not is_first_pos:
+                yield ParagraphEOF
+            is_first_pos = False
+
             n = len(para)
             if not para.strip() and relative:
                 yield n
                 continue
 
             boundaries = self._rule.apply(para.rstrip(), self.preserve_quote_and_paren)
-
-            if relative and not is_first_pos:
-                yield ParagraphEOF
-            is_first_pos = False
 
             for pos in boundaries[1:]:
                 yield offset + pos if not relative else pos

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -3,11 +3,14 @@ from importlib import import_module
 from io import TextIOBase
 from itertools import tee
 
+import sentinel
 from loguru import logger
 
 from yasbd.utils.cleaner_stub import StreamCleanerStub
 from yasbd.utils.input_validator import validate_input
 from yasbd.utils.paragraph_streamer import ParagraphStreamer
+
+ParagraphEOF = sentinel.create("ParagraphEOF")
 
 
 class BoundaryDetector:
@@ -67,26 +70,50 @@ class BoundaryDetector:
 
         self._rule = getattr(rule_module, f"{lang.capitalize()}Rules")()
 
+    def _detect_relative_spans(
+        self,
+        para_iter: Iterable[str],
+    ) -> Generator[tuple[int, int], None, None]:
+        """Yield per-paragraph sentence spans."""
+        offset = 0
+        for para in para_iter:
+            if not para.strip():
+                boundaries = [0, len(para)]
+            else:
+                boundaries = self._rule.apply(para, self.preserve_quote_and_paren)
+
+            for i in range(len(boundaries) - 1):
+                start = boundaries[i]
+                end = boundaries[i + 1]
+                yield (start, end)
+            offset += len(para)
+
     @validate_input
     def detect(
         self,
         source: str | TextIOBase | StreamCleanerStub,
         *,
         relative: bool = False,
-    ) -> Generator[tuple[int, int], None, None]:
-        """Detect sentence boundaries in text.
-
-        Yields ``(start, end)`` character offset pairs for each
-        detected sentence.
+    ) -> Generator[int, None, None]:
+        """Detect sentence boundaries in the source text.
 
         Args:
-            source: Plain text string or ``TextIOBase`` stream (e.g., ``StringIO``, opened file).
-            relative: If ``False`` (default), yield offsets relative to
-                the full text. If ``True``, offsets are per-paragraph.
+            source: Plain text string, an open text stream (e.g., ``StringIO``),
+               or a ``StreamCleaner`` instance.
+            relative: If ``False`` (default), yields absolute character
+                offsets from the beginning of the entire stream. If ``True``,
+                offsets reset at each paragraph break, yielding indices relative
+                to the start of the current paragraph.
+
+        Note:
+            When ``relative=True``, a ``ParagraphEOF`` sentinel is yielded
+            between distinct paragraphs to signal the boundary of the local
+            coordinate system. Import via: ``from yasbd import ParagraphEOF``.
 
         Yields:
-            ``(start_offset, end_offset)`` for each sentence.
+            Integer boundary offsets or ``ParagraphEOF`` sentinels.
         """
+
         if self.verbose:  # pragma: no cover
             logger.info(
                 "Called with type={}, relative={}", type(source).__name__, relative
@@ -97,42 +124,26 @@ class BoundaryDetector:
             if isinstance(source, (str, TextIOBase))
             else source
         )
-        yield from self._detect(para_iter, relative=relative)
 
-    def _detect(
-        self,
-        para_iter: Iterable[str],
-        *,
-        relative: bool = False,
-    ) -> Generator[tuple[int, int], None, None]:
-        """Internal boundary detection.
-
-        Args:
-            para_iter: An iterable of paragraph strings.
-            relative: If ``False``, yield offsets relative to
-                the full text. If ``True``, offsets are per-paragraph.
-
-        Yields:
-            ``(start_offset, end_offset)`` for each sentence.
-        """
         offset = 0
+        is_first_pos = True
         for para in para_iter:
-            if not para.strip():
-                n = len(para)
-                yield (offset, offset + n) if not relative else (0, n)
-                if not relative:
-                    offset += n
+            n = len(para)
+            if not para.strip() and relative:
+                yield n
                 continue
 
-            boundaries = self._rule.apply(para, self.preserve_quote_and_paren)
+            boundaries = self._rule.apply(para.rstrip(), self.preserve_quote_and_paren)
 
-            for i in range(len(boundaries) - 1):
-                start = boundaries[i]
-                end = boundaries[i + 1]
-                yield (offset + start, offset + end) if not relative else (start, end)
+            if relative and not is_first_pos:
+                yield ParagraphEOF
+            is_first_pos = False
+
+            for pos in boundaries[1:]:
+                yield offset + pos if not relative else pos
 
             if not relative:
-                offset += len(para)
+                offset += n
 
     @validate_input
     def segment(
@@ -162,7 +173,7 @@ class BoundaryDetector:
 
         input_for_detection, input_for_slicing = tee(para_iter)
         curr_para = None
-        for start, end in self._detect(input_for_detection, relative=True):
+        for start, end in self._detect_relative_spans(input_for_detection):
             if start == 0:
                 curr_para = next(input_for_slicing, None)
 

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -2,15 +2,17 @@ from collections.abc import Generator, Iterable
 from importlib import import_module
 from io import TextIOBase
 from itertools import tee
+from types import SimpleNamespace
 
-import sentinel
 from loguru import logger
 
 from yasbd.utils.cleaner_stub import StreamCleanerStub
 from yasbd.utils.input_validator import validate_input
 from yasbd.utils.paragraph_stream import ParagraphStream
 
-ParagraphEOF = sentinel.create("ParagraphEOF")
+# Signals transition between paragraphs in relative mode
+# during boundary detection
+ParagraphEOF = SimpleNamespace(__repr__=lambda: "ParagraphEOF")
 
 
 class BoundaryDetector:

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -2,7 +2,6 @@ from collections.abc import Generator, Iterable
 from importlib import import_module
 from io import TextIOBase
 from itertools import tee
-from types import SimpleNamespace
 
 from loguru import logger
 
@@ -12,7 +11,7 @@ from yasbd.utils.paragraph_stream import ParagraphStream
 
 # Signals transition between paragraphs in relative mode
 # during boundary detection
-ParagraphEOF = SimpleNamespace(__repr__=lambda: "ParagraphEOF")
+ParagraphEOF = type("_ParagraphEOF", (), {"__repr__": lambda self: "ParagraphEOF"})()
 
 
 class BoundaryDetector:

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -1,5 +1,4 @@
 import re  # For simpler patterns
-from collections.abc import Generator, Iterator
 
 import regex as re2
 
@@ -60,8 +59,8 @@ class Rules:
         "tbl", "tbls", "v", "vol", "vols",
 
         # Section / Structure
-        "ann", "art", "arts", "cap", "cl", "cls", "col", "cols", "para",
-        "paras", "sec", "sect", "secs", "subsec",
+        "ann", "art", "arts", "cap", "cl", "cls", "col", "cols", "text",
+        "texts", "sec", "sect", "secs", "subsec",
 
         # Legal / Numbering
         "no", "nos", "reg", "regs",
@@ -197,7 +196,7 @@ class Rules:
                 \s*\p{{Lo}}
             )|
 
-            # Split at transition between Latin letters separate by alien
+            # Split at transition between Latin letters setextte by alien
             (?<=[\p{{LU}}\p{{Ll}}][​。！？।])(?=[\p{{Lu}}])|
 
             # Cluster of terminators (e.g hello!!! r u ok?)
@@ -266,34 +265,34 @@ class Rules:
     def _remove_quote_and_paren_spans(
         self,
         main_boundaries: set[int],
-        paragraph: str,
+        text: str,
         preserve_quote_and_paren: bool,
     ) -> None:
         """Remove boundaries inside quoted/parenthesised spans."""
         if preserve_quote_and_paren:
             protected_spans = set()
-            for m in self.QUOTE_AND_PAREN_FINDER.finditer(paragraph):
+            for m in self.QUOTE_AND_PAREN_FINDER.finditer(text):
                 # Ignore first pos to preserve splits before opening quote/paren,
-                # especially for non-whitespace languages 
+                # especially for non-whitespace languages
                 protected_range = set(range(m.start() + 1 , m.end()))
                 protected_spans.update(protected_range)
             main_boundaries.difference_update(protected_spans)
 
         main_boundaries.update(
-            m.end() for m in self.QUOTE_AND_PAREN_END_FINDER.finditer(paragraph)
+            m.end() for m in self.QUOTE_AND_PAREN_END_FINDER.finditer(text)
         )
 
     def _remove_toc_spans(
-        self, main_boundaries: set[int], paragraph: str
+        self, main_boundaries: set[int], text: str
     ) -> None:
         """Remove boundaries inside TOC leader runs."""
-        if "..." in paragraph:
-            for m in self.TOC_LEADER_FINDER.finditer(paragraph):
+        if "..." in text:
+            for m in self.TOC_LEADER_FINDER.finditer(text):
                 main_boundaries.difference_update(range(*m.span()))
 
-    def _adjust_list_boundaries(self, main_boundaries: set[int], paragraph: str) -> None:
+    def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
-        horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(paragraph))
+        horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
         if len(horiz_matches) >= 2:
             main_boundaries.difference_update(m.end() for m in horiz_matches)
             # Shift boundaries the pointer back (1.\)| => |1.\), a. | => |a. ) to correctly
@@ -301,17 +300,16 @@ class Rules:
             main_boundaries.update(m.start() + 1 for m in horiz_matches if m.start())
 
         main_boundaries.difference_update(
-            m.end() for m in self.VERTICAL_LIST_START_FINDER.finditer(paragraph)
+            m.end() for m in self.VERTICAL_LIST_START_FINDER.finditer(text)
         )
 
     @validate_input
     def apply(
         self,
-        paragraph: Iterator[str],
+        text: str,
         preserve_quote_and_paren: bool,
-        relative: bool = False,
-    ) -> Generator[tuple[int, int], None, None]:
-        """Detect sentence boundaries for each paragraph.
+    ) -> list[int]:
+        """Detect sentence boundaries in *text*.
 
         Two-pass algorithm:
         1. Collect boundary candidates from punctuation positions.
@@ -319,53 +317,35 @@ class Rules:
            quote/paren spans, list markers).
 
         Args:
-            paragraph: An iterator of paragraphs.
+            text: A string to find sentence boundaries in.
             preserve_quote_and_paren: If ``True``, suppress boundaries
                inside quote and parenthesis spans.
-            relative: If ``False`` (default), yield offsets relative to
-                the full text. If ``True``, offsets are per-paragraph.
 
-        Yields:
-            ``(start_offset, end_offset)`` per sentence.
+        Returns:
+            Sorted list of character offsets at which sentences end.
         """
-        offset = 0
-        for para in paragraph:
-            if not para.strip():
-                n = len(para)
-                yield (offset, offset + n) if not relative else (0, n)
-                if not relative:
-                    offset += n
-                continue
+        text = self.NEWLINE_INSIDE_SENTENCE_FINDER.sub(" ", text)
+        main_boundaries = {
+            m.end() for m in self.NAIVE_BOUNDARY_FINDER.finditer(text)
+        }
 
-            para = self.NEWLINE_INSIDE_SENTENCE_FINDER.sub(" ", para)
-            main_boundaries = {
-                m.end() for m in self.NAIVE_BOUNDARY_FINDER.finditer(para)
-            }
+        # -- Remove false alarms --
+        main_boundaries.difference_update(
+            m.end() for m in self.MID_SENTENCE_FINDER.finditer(text)
+        )
+        self._remove_quote_and_paren_spans(
+            main_boundaries, text, preserve_quote_and_paren
+        )
+        self._remove_toc_spans(main_boundaries, text)
+        self._adjust_list_boundaries(main_boundaries, text)
 
-            # -- Remove false alarms --
-            main_boundaries.difference_update(
-                m.end() for m in self.MID_SENTENCE_FINDER.finditer(para)
+        # Remove contiguous term except last one (e.g., Hello! !!   !! )
+        main_boundaries.difference_update(
+            *(
+                range(m.start(), m.end() - 1)
+                for m in self.CONTIGUOUS_TERMINATORS_FINDER.finditer(text)
             )
-            self._remove_quote_and_paren_spans(
-                main_boundaries, para, preserve_quote_and_paren
-            )
-            self._remove_toc_spans(main_boundaries, para)
-            self._adjust_list_boundaries(main_boundaries, para)
+        )
 
-            # Remove contiguous term except last one (e.g., Hello! !!   !! )
-            main_boundaries.difference_update(
-                *(
-                    range(m.start(), m.end() - 1)
-                    for m in self.CONTIGUOUS_TERMINATORS_FINDER.finditer(para)
-                )
-            )
-
-            main_boundaries.update({0, len(para)})
-            main_boundaries_lst = sorted(main_boundaries)
-            for i in range(len(main_boundaries) - 1):
-                start = main_boundaries_lst[i]
-                end = main_boundaries_lst[i + 1]
-                yield (offset + start, offset + end) if not relative else (start, end)
-
-            if not relative:
-                offset += len(para)
+        main_boundaries.update({0, len(text)})
+        return sorted(main_boundaries)

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -59,8 +59,8 @@ class Rules:
         "tbl", "tbls", "v", "vol", "vols",
 
         # Section / Structure
-        "ann", "art", "arts", "cap", "cl", "cls", "col", "cols", "text",
-        "texts", "sec", "sect", "secs", "subsec",
+        "ann", "art", "arts", "cap", "cl", "cls", "col", "cols", "para",
+        "paras", "sec", "sect", "secs", "subsec",
 
         # Legal / Numbering
         "no", "nos", "reg", "regs",
@@ -196,7 +196,7 @@ class Rules:
                 \s*\p{{Lo}}
             )|
 
-            # Split at transition between Latin letters setextte by alien
+            # Split at transition between Latin letters separate by alien
             (?<=[\p{{LU}}\p{{Ll}}][​。！？।])(?=[\p{{Lu}}])|
 
             # Cluster of terminators (e.g hello!!! r u ok?)

--- a/src/yasbd/rules/en.py
+++ b/src/yasbd/rules/en.py
@@ -77,8 +77,6 @@ class EnRules(Rules):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    from io import StringIO
-
     rule = EnRules()
     text = """
         The system requirements for the project are simple: 1. Python 3.12 environment. 2. At least 8GB of RAM. 3. Access to the PUA character set for Sinta markers. Please ensure these are met before initialization.
@@ -91,6 +89,6 @@ if __name__ == "__main__":  # pragma: no cover
 
         The project (which had been delayed for months. ) was finally complete.
     """
-    sentences = rule.apply(StringIO(text), True)
+    sentences = rule.apply(text, True)
     for s in sentences:
         print(repr(s))

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -7,7 +7,7 @@ import regex as re2  # For complex patterns
 
 from yasbd.utils.cleaner_stub import StreamCleanerStub
 from yasbd.utils.input_validator import validate_input
-from yasbd.utils.paragraph_streamer import ParagraphStreamer
+from yasbd.utils.paragraph_stream import ParagraphStream
 
 # fmt: off
 PREFIXES = {
@@ -107,7 +107,7 @@ class StreamCleaner(StreamCleanerStub):
     @validate_input
     def __init__(self, source: str | TextIOBase) -> None:
         if isinstance(source, (str, TextIOBase)):
-            source = ParagraphStreamer(source, skip_empty_lines=True)
+            source = ParagraphStream(source, skip_empty_lines=True)
         self._source = iter(source)
 
     def __iter__(self) -> Iterator[str]:

--- a/src/yasbd/utils/paragraph_stream.py
+++ b/src/yasbd/utils/paragraph_stream.py
@@ -6,18 +6,18 @@ if TYPE_CHECKING:
     from yasbd.utils.cleaner import StreamCleaner
 
 
-class ParagraphStreamer:
+class ParagraphStream:
     """An iterator that groups lines of text into paragraph blocks.
 
     This class implements Python's Iterator Protocol (__iter__ and __next__),
     retaining state across calls and yielding reconstructed paragraph blocks.
 
     Examples:
-        >>> streamer = ParagraphStreamer('Hello\\n\\nWorld', skip_empty_lines=False)
+        >>> streamer = ParagraphStream('Hello\\n\\nWorld', skip_empty_lines=False)
         >>> list(streamer)
         ['Hello\\n\\n', 'World']
 
-        >>> streamer = ParagraphStreamer('Hello\\n\\nWorld', skip_empty_lines=True)
+        >>> streamer = ParagraphStream('Hello\\n\\nWorld', skip_empty_lines=True)
         >>> list(streamer)
         ['Hello\\n', 'World']
     """
@@ -27,7 +27,7 @@ class ParagraphStreamer:
         source: "str | TextIOBase | StreamCleaner",
         skip_empty_lines: bool = False,
     ) -> None:
-        """Initialize the ParagraphStreamer iterator.
+        """Initialize ParagraphStream.
 
         Args:
             source: Input text as a string, ``TextIOBase`` stream, or ``StreamCleaner``.
@@ -104,6 +104,6 @@ if __name__ == "__main__":  # pragma: no cover
     world"""
 
     # Correctly instantiate the iterable class and consume its stream
-    para = ParagraphStreamer(text, False)
+    para = ParagraphStream(text, False)
     for p in para:
         print(repr(p))

--- a/src/yasbd/utils/pysbd_adapter.py
+++ b/src/yasbd/utils/pysbd_adapter.py
@@ -118,10 +118,14 @@ class Segmenter:
     def _process_text(self, text: str | Iterable[str]) -> list[str | TextSpan]:
         """Detect sentence boundaries in text."""
         if self.char_span:
-            return [
-                TextSpan(text[start:end], start, end)
-                for start, end in self._detector.detect(text)
-            ]
+            boundaries = list(self._detector.detect(text))
+
+            res = []
+            start = 0
+            for end in boundaries:
+                res.append(TextSpan(text[start:end], start, end))
+                start = end
+            return res
 
         if self.clean:
             sents = list(self._detector.segment(text))

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -5,7 +5,7 @@ import string
 import pytest
 
 from tests import ALL_TEST_DATA
-from yasbd import BoundaryDetector
+from yasbd import BoundaryDetector, ParagraphEOF
 
 
 @pytest.fixture(scope="module")
@@ -78,16 +78,26 @@ def test_segment_noisy_input(en_detector):
             raise AssertionError(f"Crash on random input (len={length}): {e}") from e
 
 
-def test_include_char_span(en_detector):
-    """test that detect yields valid (start, end) offset pairs."""
+def test_detect_boundary_offsets(en_detector):
+    """test that detect yields valid boundary offsets."""
     text = "Hello World. How are you?"
 
     result = list(en_detector.detect(text))
-    assert len(result) == 2
+    assert result == [12, 25]
+    assert all(isinstance(b, int) for b in result)
+    assert result == sorted(result)
 
-    last_end = 0
-    for start, end in result:
-        assert text[start:end]
-        assert last_end <= start
-        assert start <= end
-        last_end = end
+
+def test_detect_paragraph_eof_sentinel(en_detector):
+    """test that detect yields ParagraphEOF between paragraphs in relative mode."""
+    # Single paragraph = no sentinel
+    result = list(en_detector.detect("Hello. World.", relative=True))
+    assert result == [6, 13]
+
+    # Three paragraphs = two sentinels
+    result = list(en_detector.detect("Hi.\n\nBye.\n\nOh.", relative=True))
+    assert result == [3, ParagraphEOF, 4, ParagraphEOF, 3]
+
+    # Non-relative = no sentinels,
+    result = list(en_detector.detect("First.\n\nSecond.", relative=False))
+    assert result == [6, 15]

--- a/uv.lock
+++ b/uv.lock
@@ -600,6 +600,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sentinel"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4a/d8/49115169583d02b38e7d93909a474c7ed0863f7d4df27095588344f2e66a/sentinel-1.0.0.tar.gz", hash = "sha256:190928f9951af6e94a1f84eefcaed791c28097dd152b88e988906be300451fd2", size = 6981, upload-time = "2022-07-23T10:22:19.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/c4/37cd564e7c5ee72afc864e43b872c716ed43604e50ea0adbb510d720f92d/sentinel-1.0.0-py3-none-any.whl", hash = "sha256:24f02a34cc9f0fcba5a666a23b6c7f56aff332fc624632ee442e7237751a9f60", size = 6485, upload-time = "2022-07-23T10:22:16.826Z" },
+]
+
+[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -716,6 +725,7 @@ dependencies = [
     { name = "loguru" },
     { name = "pydantic" },
     { name = "regex" },
+    { name = "sentinel" },
 ]
 
 [package.optional-dependencies]
@@ -736,5 +746,6 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1" },
     { name = "regex", specifier = ">=2025.7.29" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.14" },
+    { name = "sentinel", specifier = ">=1.0,<2.0" },
 ]
 provides-extras = ["dev"]

--- a/uv.lock
+++ b/uv.lock
@@ -600,15 +600,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sentinel"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4a/d8/49115169583d02b38e7d93909a474c7ed0863f7d4df27095588344f2e66a/sentinel-1.0.0.tar.gz", hash = "sha256:190928f9951af6e94a1f84eefcaed791c28097dd152b88e988906be300451fd2", size = 6981, upload-time = "2022-07-23T10:22:19.606Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/c4/37cd564e7c5ee72afc864e43b872c716ed43604e50ea0adbb510d720f92d/sentinel-1.0.0-py3-none-any.whl", hash = "sha256:24f02a34cc9f0fcba5a666a23b6c7f56aff332fc624632ee442e7237751a9f60", size = 6485, upload-time = "2022-07-23T10:22:16.826Z" },
-]
-
-[[package]]
 name = "tomli"
 version = "2.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -725,7 +716,6 @@ dependencies = [
     { name = "loguru" },
     { name = "pydantic" },
     { name = "regex" },
-    { name = "sentinel" },
 ]
 
 [package.optional-dependencies]
@@ -746,6 +736,5 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.2.1" },
     { name = "regex", specifier = ">=2025.7.29" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.14" },
-    { name = "sentinel", specifier = ">=1.0,<2.0" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

Three refactoring commits:

1. **Move paragraph iteration from `apply()` to `BoundaryDetector._detect()`** (`d6db686`)
   - `apply()` now takes a single string, returns `list[int]` of boundary offsets
   - Paragraph iteration, offset tracking, and empty-paragraph handling moved to boundary_detector

2. **Flatten `detect()` to yield ints, extract `_detect_spans()`** (`8175a6a`)
   - `detect()` yields individual int boundary positions instead of `(start, end)` tuples
   - `_detect_spans()` extracted for `segment()` internal use
   - `ParagraphEOF` sentinel marks paragraph transitions in relative mode

3. **Rename ParagraphStreamer to ParagraphStream** (`c1b30a3`)
   - File `paragraph_streamer.py` to `paragraph_stream.py`
   - Class `ParagraphStreamer` to `ParagraphStream`