### PR TITLE
fix: add opening bracket to reference abbreviation lookahead

### DIFF
--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -238,10 +238,10 @@ class Rules:
                rf"\b(?i:{_build_abbr_pattern(cls.MID_SENTENCE_ABBRVS)}){dots_pattern}"
             ),
 
-            # References abbrv followed by a number, a letter or opened paren (e.g., to p. 55, app. A)
+            # References abbrv followed by a number, a letter or opened paren/bracket (e.g., to p. 55, app. A, et al. [2004])
             re2.compile(rf"""
                 \b(?i:{_build_abbr_pattern(cls.REFERENCE_ABBRVS)}){dots_pattern}
-                (?=\s+(?:\(|\p{{Lu}}\b|\p{{N}}|[IVXLCDM]+))
+                (?=\s+(?:\(|\[|\p{{Lu}}\b|\p{{N}}|[IVXLCDM]+))
                 """, re2.X
             ),
 

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -79,6 +79,13 @@ TEST_DATA = [
     "My dad logged into Yahoo! finance to check on Yum! Brands stock performance before dinner.",
     "Yahoo!| The server is down.",
 
+    # Bracketed references (fix for #34)
+    "Yan et al. [2004] analysed SSH variations.| The study was comprehensive.",
+    "Fig. [1] shows the architecture.| Figure 2 provides details.",
+    "See ref. [4] for the algorithm.| The implementation follows.",
+    "As shown in pp. [55-60], the results are significant.| This confirms our hypothesis.",
+    "See sec. [2.1] for details.| The methodology is described there.",
+
     # Mixed language
     "我喜欢AI。|It is useful",
     "The meeting is at 2 p.m.| 请别迟到。",


### PR DESCRIPTION
## Summary

Fixes #34 — Reference abbreviations (et al., Fig., ref., pp., sec.) incorrectly trigger sentence splits when followed by bracketed citations like `[2004]` or `[1]`.

## Problem

The original lookahead pattern for reference abbreviations only allowed:
- `(` opening parenthesis
- uppercase letter
- number
- Roman numeral

When `et al.` was followed by `[2004]`, the lookahead failed and the period was treated as a sentence boundary.

## Solution

Added `\[` to the lookahead pattern so bracketed content is treated the same as parenthetical content — as a valid continuation after an abbreviation.

```diff
- (?=\s+(?:\(|\p{Lu}\b|\p{N}|[IVXLCDM]+))
+ (?=\s+(?:\(|\[|\p{Lu}\b|\p{N}|[IVXLCDM]+))
```

## Changes

- `src/yasbd/rules/base.py`: Added `\[` to reference abbreviation lookahead
- `tests/test_data/english.py`: Added 5 test cases covering bracketed reference patterns

## Testing

All 14 test functions (131 subtests) pass. New test cases:
- `Yan et al. [2004] analysed SSH variations...`
- `Fig. [1] shows the architecture.`
- `See ref. [4] for the algorithm.`
- `As shown in pp. [55-60], the results are significant.`
- `See sec. [2.1] for details.`
