### PR TITLE
Fix false negative for Spanish 'ave' due to street abbrv inheritance

### DIFF
--- a/src/yasbd/rules/es.py
+++ b/src/yasbd/rules/es.py
@@ -23,7 +23,7 @@ class EsRules(Rules):
 
     STREET_ABBRVS = set()
 
-    MID_SENTENCE_ABBRVS = Rules.MID_SENTENCE_ABBRVS | Rules.STREET_ABBRVS | {
+    MID_SENTENCE_ABBRVS = Rules.MID_SENTENCE_ABBRVS | {
         "ej", "p.ej", "vid", "cll", "cra", "diag", "transv", "mz", "mza", "lt",
         "urb", "asent", "dpto", "prov", "mnpio", "conj", "edif", "ofic", "km",
         "av", "avd", "c", "pso", "ctra", "pl", "blvr",

--- a/tests/test_data/spanish.py
+++ b/tests/test_data/spanish.py
@@ -22,6 +22,7 @@ TEST_DATA = [
     "La reunión es el lun. 15 de enero.",
     "Nació el 5 de abr. de 1990.",
     # Addresses & Locations
+    "Yo vi un ave.| ¿Lo has visto también?",
     "Vive en la Av. Siempre Viva.",
     "Viven en la C. Mayor, 12.",
     "El accidente fue en la Cra. 50 con Cll. 100.",


### PR DESCRIPTION
As discussed in #31, this removes the inheritance of base English street abbreviations (like `ave`, `st`, etc.) from the strict Spanish mid-sentence abbreviations, fixing the false negative. 

Added the maintainer's test case to ensure "ave" (bird) splits correctly in Spanish.