### PR TITLE
fix: don't treat mid-prose single-letter markers as list items (#52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Single-letter markers within prose** ([#52](https://github.com/speedyk-005/yasbd-lib/issues/52)): Prevented single capital-letter markers (e.g. `A.`, `B.`) embedded mid-sentence from being misclassified as flattened list items. Horizontal-list flattening now only triggers when the first marker sits at an item start (text/line start or after a terminator/closing punctuation).
+
+---
+
 ## [0.2.0] - 2026-06-04
 
 ### Added

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -311,10 +311,28 @@ class Rules:
             for m in self.TOC_LEADER_FINDER.finditer(text):
                 main_boundaries.difference_update(range(*m.span()))
 
+    @staticmethod
+    def _is_list_item_start(match, text: str) -> bool:
+        """Return True if ``match`` begins at a list-item start.
+
+        A genuine flattened list begins at the start of the text/line or
+        immediately after a sentence terminator or closing punctuation.
+        This guards against single-letter markers (e.g. ``A.``/``B.``)
+        appearing mid-sentence within ordinary prose.
+        """
+        before = text[: match.start()].rstrip()
+        return not before or before[-1] in ".!?:)"
+
     def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
         horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
-        if len(horiz_matches) >= 2:
+        # Only flatten as a genuine list when the first marker sits at an
+        # "item start" (text/line start or right after a terminator/closing
+        # punctuation). Single-letter markers embedded mid-prose (e.g.
+        # "... letter A. I know ... the B. I changed ...") are not lists.
+        if len(horiz_matches) >= 2 and self._is_list_item_start(
+            horiz_matches[0], text
+        ):
             main_boundaries.difference_update(m.end() for m in horiz_matches)
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -80,6 +80,9 @@ TEST_DATA = [
     "• 9. The first item.| • 10. The second item.",
     "a. The first item |b. The second item",
 
+    # Single-letter markers within prose (#52)
+    "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
+
     # Elipsis/TOC leaders
     "The project (Sinta) was nearing completion... or so we thought.",
     '"How could we miss this!..."| Mark shouted, slamming his hand on the desk.',

--- a/uv.lock
+++ b/uv.lock
@@ -1437,7 +1437,7 @@ wheels = [
 
 [[package]]
 name = "yasbd-lib"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "ftfy" },


### PR DESCRIPTION
## Summary

Fixes #52.

`_adjust_list_boundaries` flattened any text containing two or more single-letter markers (e.g. `A.`, `B.`) as a horizontal list, even when those markers were embedded mid-sentence in ordinary prose. This deleted the correct sentence boundary and inserted a wrong one *before* the letter.

### Before
```
['I really want letter', 'A. I know that I asked you for the', 'B. I changed my mind.']
```

### After
```
['I really want letter A.', 'I know that I asked you for the B.', 'I changed my mind.']
```

## Change

Added a context-aware guard `_is_list_item_start`: horizontal-list flattening only triggers when the **first** marker sits at an item start — the start of the text/line, or immediately after a sentence terminator / closing punctuation (`. ! ? : )`). Genuine flattened lists always begin at an item start; mid-prose markers do not.

The `HORIZONTAL_LIST_FINDER` regex is intentionally left untouched to avoid regressions in OCR/bullet cases.

## Tests
- Added an English test case in `tests/test_data/english.py`.
- Full suite passes (31 passed); existing list cases (`1.) ...`, `a) ...`, `• 9. ...`, `a. ... b. ...`) and abbreviation cases (`Q. ... A. ...`) unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a bug where single-letter capital markers (e.g., "A.", "B.") appearing within sentences were incorrectly classified as list items. List detection now properly validates that markers occur at actual list item boundaries rather than within prose text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->