### PR TITLE
Fix single-letter markers in prose segmentation

### DIFF
--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -311,10 +311,20 @@ class Rules:
             for m in self.TOC_LEADER_FINDER.finditer(text):
                 main_boundaries.difference_update(range(*m.span()))
 
+    def _horizontal_list_starts_in_list_context(self, match: re2.Match, text: str) -> bool:
+        """Return whether a horizontal list match starts a list-like context."""
+        if match.start() == 0:
+            return True
+
+        before_match = text[:match.start()].rstrip()
+        return bool(before_match) and before_match[-1] in f"{self.TERMINATORS_PATTERN}:)"
+
     def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
         horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
-        if len(horiz_matches) >= 2:
+        if len(horiz_matches) >= 2 and self._horizontal_list_starts_in_list_context(
+            horiz_matches[0], text
+        ):
             main_boundaries.difference_update(m.end() for m in horiz_matches)
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -79,6 +79,7 @@ TEST_DATA = [
     "1. The first item.| 2. The second item.",
     "• 9. The first item.| • 10. The second item.",
     "a. The first item |b. The second item",
+    "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
 
     # Elipsis/TOC leaders
     "The project (Sinta) was nearing completion... or so we thought.",


### PR DESCRIPTION
Fixes #52.\n\n## Summary\n- require horizontal list markers to begin in a list-like context before realigning boundaries\n- add regression coverage for embedded A./B. markers in prose\n\n## Tests\n- uv run pytest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of sentence boundaries when horizontal lists appear at the start of text or follow specific punctuation patterns.

* **Tests**
  * Added test coverage for English sentence patterns with list-like contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->