### PR TITLE
Fix segmentation of prose single-letter markers

### DIFF
--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -314,11 +314,33 @@ class Rules:
     def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
         horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
-        if len(horiz_matches) >= 2:
-            main_boundaries.difference_update(m.end() for m in horiz_matches)
+        list_introducers = set(self.TERMINATORS) | {":", "\n"}
+        valid_horiz_matches = []
+        last_valid_end = None
+        for match in horiz_matches:
+            if match.start() == 0:
+                is_valid = True
+            elif text[match.start() - 1] in list_introducers:
+                is_valid = True
+            elif last_valid_end is not None:
+                intervening_text = text[last_valid_end:match.start()]
+                is_valid = not any(
+                    char in self.TERMINATORS for char in intervening_text
+                )
+            else:
+                is_valid = False
+
+            if is_valid:
+                valid_horiz_matches.append(match)
+                last_valid_end = match.end()
+
+        if len(valid_horiz_matches) >= 2:
+            main_boundaries.difference_update(m.end() for m in valid_horiz_matches)
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.
-            main_boundaries.update(m.start() + 1 for m in horiz_matches if m.start())
+            main_boundaries.update(
+                m.start() + 1 for m in valid_horiz_matches if m.start()
+            )
 
         main_boundaries.difference_update(
             m.end() for m in self.VERTICAL_LIST_START_FINDER.finditer(text)

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -74,6 +74,7 @@ TEST_DATA = [
     "Hello!? !! ?!| Is that you?",
 
     # Lists
+    "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
     "1.) The first item.| 2.) The second item.",
     "a) The first item.| b) The second item.",
     "1. The first item.| 2. The second item.",


### PR DESCRIPTION
Closes #52\n\n- Restricts horizontal list boundary adjustment to markers with list-like context.\n- Adds a regression test for single-letter markers embedded in prose.\n\nTests: PYTHONPATH=src pytest tests/ -q -o addopts=''

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sentence boundary detection and positioning for horizontal list formatting to ensure proper text separation.

* **Tests**
  * Added test coverage for list formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->