### PR TITLE
fix: avoid treating single-letter prose tokens as flattened lists (#52)

### DIFF
--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -311,10 +311,36 @@ class Rules:
             for m in self.TOC_LEADER_FINDER.finditer(text):
                 main_boundaries.difference_update(range(*m.span()))
 
+    def _is_flattened_list(self, text: str, horiz_matches: list) -> bool:
+        """Decide whether *horiz_matches* describe a real flattened list.
+
+        Single-letter alphabetical tokens such as ``A.`` or ``B.`` also match
+        ``HORIZONTAL_LIST_FINDER`` even when they merely end a sentence inside
+        ordinary prose (e.g. ``"... letter A. I know ..."``). A genuine
+        flattened list is anchored: at least one marker sits at the start of
+        the text or directly after a sentence terminator/colon/newline, which
+        is where a real list item would begin. Prose markers, by contrast, are
+        embedded after normal words and are never anchored.
+        """
+        if len(horiz_matches) < 2:
+            return False
+
+        anchors = set(self.TERMINATORS) | {":", "\n"}
+        for m in horiz_matches:
+            start = m.start()
+            if start == 0:
+                return True
+            prev = start - 1
+            while prev >= 0 and text[prev].isspace():
+                prev -= 1
+            if prev >= 0 and text[prev] in anchors:
+                return True
+        return False
+
     def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
         horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
-        if len(horiz_matches) >= 2:
+        if self._is_flattened_list(text, horiz_matches):
             main_boundaries.difference_update(m.end() for m in horiz_matches)
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -79,6 +79,8 @@ TEST_DATA = [
     "1. The first item.| 2. The second item.",
     "• 9. The first item.| • 10. The second item.",
     "a. The first item |b. The second item",
+    # Single-letter prose tokens must not be treated as a flattened list (issue #52)
+    "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
 
     # Elipsis/TOC leaders
     "The project (Sinta) was nearing completion... or so we thought.",


### PR DESCRIPTION
## Summary

Fixes #52.

Single-letter alphabetical tokens such as `A.` or `B.` matched `HORIZONTAL_LIST_FINDER` even when they merely ended a sentence inside ordinary prose, so `_adjust_list_boundaries` removed the real sentence boundaries and re-aligned them before the markers, producing premature/incorrect splits.

### Before
```python
seg.segment("I really want letter A. I know that I asked you for the B. I changed my mind.")
# ['I really want letter', 'A. I know that I asked you for the', 'B. I changed my mind.']
```

### After
```python
['I really want letter A.', 'I know that I asked you for the B.', 'I changed my mind.']
```

## Approach

Added `_is_flattened_list()` which only treats matches as a real flattened list when at least one marker is **list-anchored** — i.e. at the start of the text, or directly after a sentence terminator, colon, or newline. That is where a genuine list item begins.

- Embedded prose markers (`letter A.`, `the B.`) are never anchored, so normal sentences segment correctly.
- Genuine flattened / OCR lists still have their first marker anchored (string start or after a terminator), so existing behavior is preserved.

The change lives in the shared `Rules` base class, so it applies consistently across all languages.

## Tests

- Added a regression case to `tests/test_data/english.py`:
  `"I really want letter A.| I know that I asked you for the B.| I changed my mind."`
- Verified existing flattened-list cases still pass (`1. ... 2. ...`, `a. ... b. ...`, `a) ... b) ...`, `1.) ... 2.) ...`, `• 9. ... • 10. ...`).
- Full suite: `28 passed, 318 subtests passed`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect identification of single-letter prose tokens as list items (Issue `#52`).
  * Improved list boundary detection to more accurately distinguish actual list markers from incidental matches within text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->