### PR TITLE
Fix single-letter prose marker segmentation

### DIFF
--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -311,10 +311,30 @@ class Rules:
             for m in self.TOC_LEADER_FINDER.finditer(text):
                 main_boundaries.difference_update(range(*m.span()))
 
+    @staticmethod
+    def _is_alpha_dot_list_context(
+        text: str, horiz_matches: list[re2.Match]
+    ) -> bool:
+        """Return True when alphabetic dot markers look like a real list."""
+        alpha_dot_matches = [
+            m for m in horiz_matches if re2.match(r"\s*[A-Ea-e]\.", m.group())
+        ]
+        if len(alpha_dot_matches) != len(horiz_matches):
+            return True
+
+        first_match = alpha_dot_matches[0]
+        if first_match.start() == 0:
+            return True
+
+        prefix = text[: first_match.start()].rstrip()
+        return bool(prefix) and prefix[-1] in ":\n"
+
     def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
         horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
-        if len(horiz_matches) >= 2:
+        if len(horiz_matches) >= 2 and self._is_alpha_dot_list_context(
+            text, horiz_matches
+        ):
             main_boundaries.difference_update(m.end() for m in horiz_matches)
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -29,6 +29,7 @@ TEST_DATA = [
     "I need you to find 3 items, e.g. a hat, a coat, and a bag.",
     "The report was published in Dec.| It was approved by Prof. Smith and Dr. Jones.",
     "The agreement was signed by A.B. Holdings Ltd. in 2024",
+    "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
     "The temperature reached 37.5°C at 6 a.m. on Tue., Feb. 4.",
     "See fig. 2 in vol. 3, ch. 4, pp. 18-22.",
     "The proof is shown in eq. (7) and ex. IV",


### PR DESCRIPTION
Closes #52.\n\n## Summary\n- avoid treating inline alphabetic dot tokens as flattened list markers unless they appear at the start or after list-introducing punctuation\n- add regression coverage for single-letter prose tokens followed by periods\n\n## Tests\n- uv run --with pytest-cov pytest -q\n- uv run --with ruff ruff check src/yasbd/rules/base.py\n- uv run --with ruff ruff format --check src/yasbd/rules/base.py\n\nNote: full ruff over tests reports pre-existing E501 line length issues in test data files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced detection of alphabetic-style lists (A., B., C., etc.) in sentence boundary recognition to ensure proper identification only within authentic list contexts, reducing false positives in general text.

* **Tests**
  * Added test case to verify correct handling of English-language alphabetic lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->