### PR TITLE
fix(rules): prevent single-letter markers in prose from being misclassified as list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Incorrect segmentation of single-letter markers within sentences** ([#52](https://github.com/speedyk-005/yasbd-lib/issues/52)): Prevents embedded single-letter markers (e.g., `A.`, `B.`) in prose from being misclassified as horizontal list items. Adds an item-start context check to `_adjust_list_boundaries`.
+
 ## [0.2.0] - 2026-06-04
 
 ### Added

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -311,10 +311,20 @@ class Rules:
             for m in self.TOC_LEADER_FINDER.finditer(text):
                 main_boundaries.difference_update(range(*m.span()))
 
+    def _is_at_item_start(self, match, text: str) -> bool:
+        """Check whether a horizontal-list match begins a genuine list item."""
+        start = match.start()
+        if start == 0:
+            return True
+        prefix = text[:start].rstrip()
+        if not prefix:
+            return False
+        return prefix[-1] in self.TERMINATORS or prefix[-1] in ":)"
+
     def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
         horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
-        if len(horiz_matches) >= 2:
+        if len(horiz_matches) >= 2 and self._is_at_item_start(horiz_matches[0], text):
             main_boundaries.difference_update(m.end() for m in horiz_matches)
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -80,6 +80,9 @@ TEST_DATA = [
     "• 9. The first item.| • 10. The second item.",
     "a. The first item |b. The second item",
 
+    # Single-letter markers in prose (fix for #52)
+    "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
+
     # Elipsis/TOC leaders
     "The project (Sinta) was nearing completion... or so we thought.",
     '"How could we miss this!..."| Mark shouted, slamming his hand on the desk.',


### PR DESCRIPTION
Adds an item-start context check to `_adjust_list_boundaries` so that embedded single-letter markers (e.g., 'A.', 'B.') inside ordinary sentences no longer trigger horizontal-list flattening.

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* **Fixed incorrect sentence segmentation with single-letter markers** - Previously, single-letter markers appearing within regular prose (such as "See item A." or "Reference B.") were incorrectly identified as list item boundaries, causing improper sentence splitting. The system now examines contextual clues to accurately distinguish between embedded markers in normal text and actual list items, improving overall segmentation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->