### PR TITLE
fix: prevent single-letter prose tokens from being treated as horizontal list markers

### DIFF
--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -311,10 +311,20 @@ class Rules:
             for m in self.TOC_LEADER_FINDER.finditer(text):
                 main_boundaries.difference_update(range(*m.span()))
 
+    def _has_list_start_context(self, text: str, horiz_matches) -> bool:
+        """Return True if at least one match has clear list-start context."""
+        for m in horiz_matches:
+            start = m.start()
+            if start == 0:
+                return True
+            if text[start - 1] in {".", "!", "?", ":", ";", "\n", "\r"}:
+                return True
+        return False
+
     def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
         horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
-        if len(horiz_matches) >= 2:
+        if len(horiz_matches) >= 2 and self._has_list_start_context(text, horiz_matches):
             main_boundaries.difference_update(m.end() for m in horiz_matches)
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -34,6 +34,9 @@ TEST_DATA = [
     "The proof is shown in eq. (7) and ex. IV",
     "Mr. Smith lives on Hwy. 7 near Ave. Central.",
     "The delivery van broke down right in front of Sunset Blvd.| The driver called a tow truck.",
+
+    # Single-letter markers in prose (fix for #52)
+    "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
     "I'll see you on Fri., Feb. 14th. ",
     "You can find it at N°. 1026.253.553.| That is where the treasure is.",
     "We make a good team, you and I.| Did you see Albert I. Jones yesterday?",


### PR DESCRIPTION
Fixes #52

## Problem
``_adjust_list_boundaries`` was too aggressive: any text with at least two ``HORIZONTAL_LIST_FINDER`` matches was treated as a flattened list. This caused prose containing single-letter tokens (e.g. `"letter A."`, `"the B."`) to be split incorrectly.

## Solution
Add a ``_has_list_start_context`` helper that requires at least one horizontal-list match to have clear list-start context (start of text or immediately after punctuation). Only when this stronger evidence is present do we re-align boundaries around list markers.

## Changes
- ``src/yasbd/rules/base.py``: added ``_has_list_start_context`` and updated ``_adjust_list_boundaries``
- ``tests/test_data/english.py``: added regression test for issue #52

## Verification
- All existing list test cases still pass (flattened alphabetic, numeric, and bullet lists)
- New regression test passes
- Full test suite passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of single-letter markers appearing within prose text.
  * Improved detection and alignment of list markers at sentence and list boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->