### PR TITLE
fix: avoid mis-segmenting single-letter markers in prose

### DIFF
--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -314,11 +314,33 @@ class Rules:
     def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
         horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
-        if len(horiz_matches) >= 2:
-            main_boundaries.difference_update(m.end() for m in horiz_matches)
+        valid_matches = []
+        last_valid_end = None
+        for m in horiz_matches:
+            start = m.start()
+            if start == 0:
+                valid_matches.append(m)
+                last_valid_end = m.end()
+                continue
+
+            prev_char = text[start - 1]
+            if prev_char in self.TERMINATORS or prev_char in {':', '\n'}:
+                valid_matches.append(m)
+                last_valid_end = m.end()
+                continue
+
+            if last_valid_end is not None:
+                slice_between = text[last_valid_end:start]
+                if not any(c in self.TERMINATORS for c in slice_between):
+                    valid_matches.append(m)
+                    last_valid_end = m.end()
+                    continue
+
+        if len(valid_matches) >= 2:
+            main_boundaries.difference_update(m.end() for m in valid_matches)
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.
-            main_boundaries.update(m.start() + 1 for m in horiz_matches if m.start())
+            main_boundaries.update(m.start() + 1 for m in valid_matches if m.start())
 
         main_boundaries.difference_update(
             m.end() for m in self.VERTICAL_LIST_START_FINDER.finditer(text)

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -80,6 +80,10 @@ TEST_DATA = [
     "• 9. The first item.| • 10. The second item.",
     "a. The first item |b. The second item",
 
+    # Single-letter markers in prose (fix for #52)
+    "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
+    "I am number 1.| I am number 2.| I changed my mind.",
+
     # Elipsis/TOC leaders
     "The project (Sinta) was nearing completion... or so we thought.",
     '"How could we miss this!..."| Mark shouted, slamming his hand on the desk.',


### PR DESCRIPTION
Fixes #52

Adjusts `_adjust_list_boundaries` to only treat horizontal list matches as valid list markers when they:
- appear at paragraph start,
- follow a sentence terminator, colon, or newline, or  
- continue an existing list chain with no intervening terminator.

This prevents false positives like `letter A.` and `the B.` from being treated as list items while preserving correct splitting for actual horizontal lists.

Adds regression tests for the issue example and numeric markers in prose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced sentence boundary detection for horizontal lists to correctly handle edge cases.

* **Tests**
  * Added test coverage for single-letter markers appearing in prose text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->