### PR TITLE
Prevent single-letter markers from being treated as list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Superscript indicator false splits**: Added protection to prevent boundary breaks after ordinal markers.
 - **Em-dash quoted text splitting**: Added em-dash pattern to `QUOTE_AND_PAREN_FINDER` so dialogue quoted with dashes (`—text! —`) is no longer split prematurely.
 - **Newline boundary handling** ([#64](https://github.com/speedyk-005/yasbd-lib/pull/64)): Added `\n` to `NAIVE_BOUNDARY_FINDER` and updated `NEWLINE_INSIDE_SENTENCE_FINDER` to recognize `>` continuation, preventing markdown heading merging.
+- **Single-letter list marker false splits** ([#71](https://github.com/speedyk-005/yasbd-lib/pull/71)): Added context-aware heuristic to `_adjust_list_boundaries` so standalone "A." or "B." in prose are no longer split as list items.
 
 ## [0.2.0] - 2026-06-04
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -318,7 +318,17 @@ class Rules:
     def _adjust_list_boundaries(self, main_boundaries: set[int], text: str) -> None:
         """Remove and re-align boundaries around list markers."""
         horiz_matches = list(self.HORIZONTAL_LIST_FINDER.finditer(text))
-        if len(horiz_matches) >= 2:
+
+        # Quick contextual heuristic
+        is_flattened_list = (
+            len(horiz_matches) >= 2
+            and  (
+                ":" in text
+                or text[horiz_matches[0].start()] == text.lstrip()[0]
+            )
+        )
+
+        if is_flattened_list:
             main_boundaries.difference_update(m.end() for m in horiz_matches)
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -322,7 +322,7 @@ class Rules:
         # Quick contextual heuristic
         is_flattened_list = (
             len(horiz_matches) >= 2
-            and  (
+            and (
                 ":" in text
                 or text[horiz_matches[0].start()] == text.lstrip()[0]
             )

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -80,6 +80,10 @@ TEST_DATA = [
     "• 9. The first item.| • 10. The second item.",
     "a. The first item |b. The second item",
 
+    # Not a list (fix for #52)
+    "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
+    "You are going to the store, and so am I.| We can go together.",
+
     # Elipsis/TOC leaders
     "The project (Sinta) was nearing completion... or so we thought.",
     '"How could we miss this!..."| Mark shouted, slamming his hand on the desk.',


### PR DESCRIPTION
Part #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list detection to avoid false splits for single-letter or list-like text by adding context-aware checks.

* **Tests**
  * Added a test case to validate sentence-splitting when content resembles list formatting.

* **Documentation**
  * Updated changelog to note the fix to list-detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->