### PR TITLE
docs: replace python_docstring_markdown with pydoc-markdown

### DIFF
--- a/API_REFERENCES.md
+++ b/API_REFERENCES.md
@@ -1,760 +1,708 @@
-# `yasbd`
+# Table of Contents
 
-## Table of Contents
+* [yasbd](#yasbd)
+* [yasbd.boundary\_detector](#yasbd.boundary_detector)
+  * [BoundaryDetector](#yasbd.boundary_detector.BoundaryDetector)
+    * [\_\_init\_\_](#yasbd.boundary_detector.BoundaryDetector.__init__)
+    * [lang](#yasbd.boundary_detector.BoundaryDetector.lang)
+    * [detect](#yasbd.boundary_detector.BoundaryDetector.detect)
+    * [segment](#yasbd.boundary_detector.BoundaryDetector.segment)
+* [yasbd.cli](#yasbd.cli)
+  * [segment](#yasbd.cli.segment)
+  * [detect](#yasbd.cli.detect)
+  * [clean](#yasbd.cli.clean)
+  * [langs](#yasbd.cli.langs)
+  * [main](#yasbd.cli.main)
+* [yasbd.exceptions](#yasbd.exceptions)
+  * [YasbdError](#yasbd.exceptions.YasbdError)
+  * [UnsupportedLanguageError](#yasbd.exceptions.UnsupportedLanguageError)
+  * [InvalidInputError](#yasbd.exceptions.InvalidInputError)
+  * [CleanStepError](#yasbd.exceptions.CleanStepError)
+* [yasbd.rules](#yasbd.rules)
+  * [get\_supported\_langs](#yasbd.rules.get_supported_langs)
+* [yasbd.rules.ar](#yasbd.rules.ar)
+* [yasbd.rules.base](#yasbd.rules.base)
+  * [Rules](#yasbd.rules.base.Rules)
+    * [\_\_init\_\_](#yasbd.rules.base.Rules.__init__)
+    * [apply](#yasbd.rules.base.Rules.apply)
+* [yasbd.rules.de](#yasbd.rules.de)
+* [yasbd.rules.en](#yasbd.rules.en)
+* [yasbd.rules.es](#yasbd.rules.es)
+* [yasbd.rules.fr](#yasbd.rules.fr)
+* [yasbd.rules.ht](#yasbd.rules.ht)
+* [yasbd.rules.ja](#yasbd.rules.ja)
+* [yasbd.rules.pt](#yasbd.rules.pt)
+* [yasbd.rules.ru](#yasbd.rules.ru)
+* [yasbd.rules.zh](#yasbd.rules.zh)
+* [yasbd.utils](#yasbd.utils)
+* [yasbd.utils.cleaner](#yasbd.utils.cleaner)
+  * [StreamCleaner](#yasbd.utils.cleaner.StreamCleaner)
+    * [\_\_init\_\_](#yasbd.utils.cleaner.StreamCleaner.__init__)
+* [yasbd.utils.input\_validator](#yasbd.utils.input_validator)
+  * [validate\_input](#yasbd.utils.input_validator.validate_input)
+* [yasbd.utils.logger](#yasbd.utils.logger)
+  * [log\_info](#yasbd.utils.logger.log_info)
+* [yasbd.utils.paragraph\_stream](#yasbd.utils.paragraph_stream)
+  * [ParagraphStream](#yasbd.utils.paragraph_stream.ParagraphStream)
+    * [\_\_init\_\_](#yasbd.utils.paragraph_stream.ParagraphStream.__init__)
+    * [\_\_next\_\_](#yasbd.utils.paragraph_stream.ParagraphStream.__next__)
+* [yasbd.utils.pysbd\_adapter](#yasbd.utils.pysbd_adapter)
+  * [TextSpan](#yasbd.utils.pysbd_adapter.TextSpan)
+  * [Segmenter](#yasbd.utils.pysbd_adapter.Segmenter)
+    * [\_\_init\_\_](#yasbd.utils.pysbd_adapter.Segmenter.__init__)
+    * [sentences\_with\_char\_spans](#yasbd.utils.pysbd_adapter.Segmenter.sentences_with_char_spans)
+    * [segment](#yasbd.utils.pysbd_adapter.Segmenter.segment)
 
-- 🅼 [yasbd](#yasbd)
-- 🅼 [yasbd\.boundary\_detector](#yasbd-boundary_detector)
-- 🅼 [yasbd\.cli](#yasbd-cli)
-- 🅼 [yasbd\.exceptions](#yasbd-exceptions)
-- 🅼 [yasbd\.rules](#yasbd-rules)
-- 🅼 [yasbd\.rules\.ar](#yasbd-rules-ar)
-- 🅼 [yasbd\.rules\.base](#yasbd-rules-base)
-- 🅼 [yasbd\.rules\.de](#yasbd-rules-de)
-- 🅼 [yasbd\.rules\.en](#yasbd-rules-en)
-- 🅼 [yasbd\.rules\.es](#yasbd-rules-es)
-- 🅼 [yasbd\.rules\.fr](#yasbd-rules-fr)
-- 🅼 [yasbd\.rules\.ht](#yasbd-rules-ht)
-- 🅼 [yasbd\.rules\.ja](#yasbd-rules-ja)
-- 🅼 [yasbd\.rules\.pt](#yasbd-rules-pt)
-- 🅼 [yasbd\.rules\.ru](#yasbd-rules-ru)
-- 🅼 [yasbd\.rules\.zh](#yasbd-rules-zh)
-- 🅼 [yasbd\.utils](#yasbd-utils)
-- 🅼 [yasbd\.utils\.cleaner](#yasbd-utils-cleaner)
-- 🅼 [yasbd\.utils\.cleaner\_stub](#yasbd-utils-cleaner_stub)
-- 🅼 [yasbd\.utils\.input\_validator](#yasbd-utils-input_validator)
-- 🅼 [yasbd\.utils\.paragraph\_stream](#yasbd-utils-paragraph_stream)
-- 🅼 [yasbd\.utils\.pysbd\_adapter](#yasbd-utils-pysbd_adapter)
+<a id="yasbd"></a>
 
-<a name="yasbd"></a>
-## 🅼 yasbd
+# yasbd
 
-- **[Exports](#yasbd-exports)**
+<a id="yasbd.boundary_detector"></a>
 
-<a name="yasbd-exports"></a>
-### Exports
+# yasbd.boundary\_detector
 
-- 🅼 [`BoundaryDetector`](#yasbd-BoundaryDetector)
-- 🅼 [`ParagraphEOF`](#yasbd-ParagraphEOF)
-- 🅼 [`InvalidInputError`](#yasbd-InvalidInputError)
-- 🅼 [`UnsupportedLanguageError`](#yasbd-UnsupportedLanguageError)
-- 🅼 [`YasbdError`](#yasbd-YasbdError)
-- 🅼 [`get_supported_langs`](#yasbd-get_supported_langs)
-- 🅼 [`__version__`](#yasbd-__version__)
-<a name="yasbd-boundary_detector"></a>
-## 🅼 yasbd\.boundary\_detector
+<a id="yasbd.boundary_detector.BoundaryDetector"></a>
 
-- **Classes:**
-  - 🅲 [BoundaryDetector](#yasbd-boundary_detector-BoundaryDetector)
-
-### Classes
-
-<a name="yasbd-boundary_detector-BoundaryDetector"></a>
-### 🅲 yasbd\.boundary\_detector\.BoundaryDetector
-
-```python
-class BoundaryDetector:
-```
-
-**Functions:**
-
-<a name="yasbd-boundary_detector-BoundaryDetector-__init__"></a>
-#### 🅵 yasbd\.boundary\_detector\.BoundaryDetector\.\_\_init\_\_
-
-```python
-def __init__(self, lang: str = 'en', preserve_quote_and_paren: bool = True, verbose: bool = False):
-```
-
-Initialize the segmenter\.
-
-**Parameters:**
-
-- **lang**: Two chars ISO language code \(e\.g\. en, fr, \.\.\.\)\.
-- **preserve_quote_and_paren**: Do not split on terminators inside
-quoted or parenthesised text\.
-- **verbose**: Enable verbose logging\.
-<a name="yasbd-boundary_detector-BoundaryDetector-lang"></a>
-#### 🅵 yasbd\.boundary\_detector\.BoundaryDetector\.lang
+## BoundaryDetector Objects
 
 ```python
-def lang(self) -> str:
+class BoundaryDetector()
 ```
 
-ISO language code of the active rule set\.
-<a name="yasbd-boundary_detector-BoundaryDetector-lang"></a>
-#### 🅵 yasbd\.boundary\_detector\.BoundaryDetector\.lang
+<a id="yasbd.boundary_detector.BoundaryDetector.__init__"></a>
+
+#### \_\_init\_\_
 
 ```python
-def lang(self, lang: str) -> None:
+@validate_input
+def __init__(lang: str = "en",
+             *,
+             preserve_quote_and_paren: bool = True,
+             verbose: bool = False)
 ```
-<a name="yasbd-boundary_detector-BoundaryDetector-detect"></a>
-#### 🅵 yasbd\.boundary\_detector\.BoundaryDetector\.detect
+
+Initialize the segmenter.
+
+**Arguments**:
+
+- `lang` - Two chars ISO language code (e.g. en, fr, ...).
+- `preserve_quote_and_paren` - Do not split on terminators inside
+  quoted or parenthesised text.
+- `verbose` - Enable verbose logging.
+
+<a id="yasbd.boundary_detector.BoundaryDetector.lang"></a>
+
+#### lang
 
 ```python
-def detect(self, source: str | TextIOBase | StreamCleanerStub, relative: bool = False) -> Generator[int, None, None]:
+@property
+def lang() -> str
 ```
 
-Detect sentence boundaries in the source text\.
+ISO language code of the active rule set.
 
-**Parameters:**
+<a id="yasbd.boundary_detector.BoundaryDetector.detect"></a>
 
-- **source**: Plain text string, an open text stream \(e\.g\., \`\`StringIO\`\`\),
-or a \`\`StreamCleaner\`\` instance\.
-- **relative**: If \`\`False\`\` \(default\), yields absolute character
-offsets from the beginning of the entire stream\. If \`\`True\`\`,
-offsets reset at each paragraph break, yielding indices relative
-to the start of the current paragraph\.
-<a name="yasbd-boundary_detector-BoundaryDetector-segment"></a>
-#### 🅵 yasbd\.boundary\_detector\.BoundaryDetector\.segment
+#### detect
 
 ```python
-def segment(self, source: str | TextIOBase | StreamCleanerStub, preserve_whitespace: bool = False) -> Generator[str, None, None]:
+@validate_input
+def detect(source: str | TextIOBase | StreamCleanerStub,
+           *,
+           relative: bool = False) -> Generator[int, None, None]
 ```
 
-Split text into sentences\.
+Detect sentence boundaries in the source text.
 
-**Parameters:**
+**Arguments**:
 
-- **source**: Plain text string or \`\`TextIOBase\`\` stream
-\(e\.g\., \`\`StringIO\`\`, opened file\)\.
-- **preserve_whitespace**: If \`\`False\`\` \(default\), strip leading and
-trailing whitespace from each sentence\.
-<a name="yasbd-cli"></a>
-## 🅼 yasbd\.cli
+- `source` - Plain text string, an open text stream (e.g., ``StringIO``),
+  or a ``StreamCleaner`` instance.
+- `relative` - If ``False`` (default), yields absolute character
+  offsets from the beginning of the entire stream. If ``True``,
+  offsets reset at each paragraph break, yielding indices relative
+  to the start of the current paragraph.
+  
 
-- **Functions:**
-  - 🅵 [segment](#yasbd-cli-segment)
-  - 🅵 [detect](#yasbd-cli-detect)
-  - 🅵 [clean](#yasbd-cli-clean)
-  - 🅵 [langs](#yasbd-cli-langs)
-  - 🅵 [main](#yasbd-cli-main)
+**Notes**:
 
-### Functions
+  When ``relative=True``, a ``ParagraphEOF`` sentinel is yielded
+  between distinct paragraphs to signal the boundary of the local
+  coordinate system. Import via: ``from yasbd import ParagraphEOF``.
+  
 
-<a name="yasbd-cli-segment"></a>
-### 🅵 yasbd\.cli\.segment
+**Yields**:
+
+  Integer boundary offsets or ``ParagraphEOF`` sentinels.
+
+<a id="yasbd.boundary_detector.BoundaryDetector.segment"></a>
+
+#### segment
 
 ```python
-def segment(text: Optional[str] = None, file: Optional[str] = None, destination: Optional[str] = None, lang: str = 'en', preserve_whitespace: bool = False, verbose: bool = False):
+@validate_input
+def segment(source: str | TextIOBase | StreamCleanerStub,
+            *,
+            preserve_whitespace: bool = False) -> Generator[str, None, None]
 ```
 
-Split text into sentences\.
-<a name="yasbd-cli-detect"></a>
-### 🅵 yasbd\.cli\.detect
+Split text into sentences.
+
+**Arguments**:
+
+- `source` - Plain text string or ``TextIOBase`` stream
+  (e.g., ``StringIO``, opened file).
+- `preserve_whitespace` - If ``False`` (default), strip leading and
+  trailing whitespace from each sentence.
+  
+
+**Yields**:
+
+  Individual sentences as strings.
+
+<a id="yasbd.cli"></a>
+
+# yasbd.cli
+
+<a id="yasbd.cli.segment"></a>
+
+#### segment
 
 ```python
-def detect(text: Optional[str] = None, file: Optional[str] = None, destination: Optional[str] = None, lang: str = 'en', relative: bool = False, verbose: bool = False):
+@cli.command(
+    "segment",
+    text=Arg(help="Text to split. Use --file to read from a file instead."),
+    file=Arg("--file", "-f", help="Read input from a text file."),
+    destination=Arg("--destination", "-d", help="Write output to a file."),
+    lang=Arg("--lang", "-l", help="Language code (e.g., 'en', 'fr', 'de')."),
+    preserve_whitespace=Arg("--preserve-whitespace",
+                            "-w",
+                            help="Preserve original whitespace in output."),
+    verbose=Arg("--verbose", "-v", help="Enable verbose logging."),
+)
+def segment(text: Optional[str] = None,
+            file: Optional[str] = None,
+            destination: Optional[str] = None,
+            lang: str = "en",
+            preserve_whitespace: bool = False,
+            verbose: bool = False)
 ```
 
-Detect sentence boundary offsets \(character positions\)\.
-<a name="yasbd-cli-clean"></a>
-### 🅵 yasbd\.cli\.clean
+Split text into sentences.
+
+Reads from a positional string, --file, or stdin pipe.
+Writes enumerated sentences to stdout or JSONL to --destination.
+
+<a id="yasbd.cli.detect"></a>
+
+#### detect
 
 ```python
-def clean(text: Optional[str] = None, file: Optional[str] = None, destination: Optional[str] = None, steps_to_skip: Optional[str] = None, verbose: bool = False):
+@cli.command(
+    "detect",
+    text=Arg(
+        help=
+        "Text to detect boundaries in. Use --file to read from a file instead."
+    ),
+    file=Arg("--file", "-f", help="Read input from a text file."),
+    destination=Arg("--destination",
+                    "-d",
+                    help="Write boundary offsets to a file."),
+    lang=Arg("--lang", "-l", help="Language code (e.g., 'en', 'fr', 'de')."),
+    relative=Arg("--relative", "-r", help="Yield paragraph-relative offsets."),
+    verbose=Arg("--verbose", "-v", help="Enable verbose logging."),
+)
+def detect(text: Optional[str] = None,
+           file: Optional[str] = None,
+           destination: Optional[str] = None,
+           lang: str = "en",
+           relative: bool = False,
+           verbose: bool = False)
 ```
 
-Clean and normalize noisy text paragraphs\.
-<a name="yasbd-cli-langs"></a>
-### 🅵 yasbd\.cli\.langs
+Detect sentence boundary offsets (character positions).
+
+Reads from a positional string, --file, or stdin pipe.
+Writes boundary offsets to stdout or JSONL to --destination.
+Use --relative for per-paragraph offsets (ParagraphEOF marks gaps).
+
+<a id="yasbd.cli.clean"></a>
+
+#### clean
 
 ```python
-def langs():
+@cli.command(
+    "clean",
+    text=Arg(help="Text to clean. Use --file to read from a file instead."),
+    file=Arg("--file", "-f", help="Read input from a text file."),
+    destination=Arg("--destination",
+                    "-d",
+                    help="Write cleaned text to a file."),
+    steps_to_skip=Arg("--steps-to-skip",
+                      "--skip",
+                      help="Comma-separated cleaning steps to skip."),
+    extra_step=Arg(
+        "--extra-step",
+        "-e",
+        help=
+        "External shell command to run as an extra cleaning step (repeatable).",
+    ),
+    verbose=Arg("--verbose", "-v", help="Enable verbose logging."),
+)
+def clean(text: Optional[str] = None,
+          file: Optional[str] = None,
+          destination: Optional[str] = None,
+          steps_to_skip: Optional[str] = None,
+          extra_step: Optional[list[str]] = None,
+          verbose: bool = False)
 ```
 
-List supported language codes\.
-<a name="yasbd-cli-main"></a>
-### 🅵 yasbd\.cli\.main
+Clean and normalize noisy text paragraphs.
+
+Applies ftfy mojibake fixing, OCR cleanup, HTML tag stripping,
+slash normalization, and whitespace normalization.
+Use --skip to omit specific steps (comma-separated).
+Use --extra-step to run external shell commands as extra cleaning steps.
+
+<a id="yasbd.cli.langs"></a>
+
+#### langs
 
 ```python
-def main():
+@cli.command("langs")
+def langs()
 ```
-<a name="yasbd-exceptions"></a>
-## 🅼 yasbd\.exceptions
 
-- **Classes:**
-  - 🅲 [YasbdError](#yasbd-exceptions-YasbdError)
-  - 🅲 [UnsupportedLanguageError](#yasbd-exceptions-UnsupportedLanguageError)
-  - 🅲 [InvalidInputError](#yasbd-exceptions-InvalidInputError)
+List supported language codes.
 
-### Classes
+<a id="yasbd.cli.main"></a>
 
-<a name="yasbd-exceptions-YasbdError"></a>
-### 🅲 yasbd\.exceptions\.YasbdError
+#### main
 
 ```python
-class YasbdError(Exception):
+def main()
 ```
 
-Base exception for all yasbd errors\.
-<a name="yasbd-exceptions-UnsupportedLanguageError"></a>
-### 🅲 yasbd\.exceptions\.UnsupportedLanguageError
+CLI entry point. Handles --version, --help, and dispatches to radicli.
+
+<a id="yasbd.exceptions"></a>
+
+# yasbd.exceptions
+
+<a id="yasbd.exceptions.YasbdError"></a>
+
+## YasbdError Objects
 
 ```python
-class UnsupportedLanguageError(YasbdError, ValueError):
+class YasbdError(Exception)
 ```
 
-Raised when an unsupported language code is provided\.
-<a name="yasbd-exceptions-InvalidInputError"></a>
-### 🅲 yasbd\.exceptions\.InvalidInputError
+Base exception for all yasbd errors.
+
+<a id="yasbd.exceptions.UnsupportedLanguageError"></a>
+
+## UnsupportedLanguageError Objects
 
 ```python
-class InvalidInputError(YasbdError, TypeError):
+class UnsupportedLanguageError(YasbdError, ValueError)
 ```
 
-Raised when invalid input\(s\) are encountered\.
-<a name="yasbd-rules"></a>
-## 🅼 yasbd\.rules
+Raised when an unsupported language code is provided.
 
-- **Functions:**
-  - 🅵 [get\_supported\_langs](#yasbd-rules-get_supported_langs)
+<a id="yasbd.exceptions.InvalidInputError"></a>
 
-### Functions
-
-<a name="yasbd-rules-get_supported_langs"></a>
-### 🅵 yasbd\.rules\.get\_supported\_langs
+## InvalidInputError Objects
 
 ```python
-def get_supported_langs() -> list[str]:
+class InvalidInputError(YasbdError, TypeError)
 ```
 
-Discover and cache supported language codes from the rules directory\.
-<a name="yasbd-rules-ar"></a>
-## 🅼 yasbd\.rules\.ar
+Raised when invalid input(s) are encountered.
 
-- **Classes:**
-  - 🅲 [ArRules](#yasbd-rules-ar-ArRules)
+<a id="yasbd.exceptions.CleanStepError"></a>
 
-### Classes
-
-<a name="yasbd-rules-ar-ArRules"></a>
-### 🅲 yasbd\.rules\.ar\.ArRules
+## CleanStepError Objects
 
 ```python
-class ArRules(Rules):
+class CleanStepError(YasbdError, TypeError)
 ```
-<a name="yasbd-rules-base"></a>
-## 🅼 yasbd\.rules\.base
 
-- **Classes:**
-  - 🅲 [Rules](#yasbd-rules-base-Rules)
+Raised when a StreamCleaner extra step fails (non-callable or non-str return).
 
-### Classes
+<a id="yasbd.rules"></a>
 
-<a name="yasbd-rules-base-Rules"></a>
-### 🅲 yasbd\.rules\.base\.Rules
+# yasbd.rules
+
+<a id="yasbd.rules.get_supported_langs"></a>
+
+#### get\_supported\_langs
 
 ```python
-class Rules:
+@cache
+def get_supported_langs() -> list[str]
 ```
 
-**Functions:**
+Discover and cache supported language codes from the rules directory.
 
-<a name="yasbd-rules-base-Rules-__init__"></a>
-#### 🅵 yasbd\.rules\.base\.Rules\.\_\_init\_\_
+<a id="yasbd.rules.ar"></a>
+
+# yasbd.rules.ar
+
+<a id="yasbd.rules.base"></a>
+
+# yasbd.rules.base
+
+<a id="yasbd.rules.base.Rules"></a>
+
+## Rules Objects
 
 ```python
-def __init__(self):
+class Rules()
 ```
 
-Initialize rule instance with lazy-compiled regex patterns\.
+<a id="yasbd.rules.base.Rules.__init__"></a>
 
-Patterns are compiled once per class and cached via \`\`\_REGEX\_CACHED\`\`\.
-Subclasses can override data constants \(abbreviation sets, terminators, etc\.\)
-and the classmethod \`\`\_compile\_regex\_dynamically\`\` will pick them up\.
-<a name="yasbd-rules-base-Rules-apply"></a>
-#### 🅵 yasbd\.rules\.base\.Rules\.apply
+#### \_\_init\_\_
 
 ```python
-def apply(self, text: str, preserve_quote_and_paren: bool) -> list[int]:
+def __init__()
 ```
 
-Detect sentence boundaries in \*text\*\.
+Initialize rule instance with lazy-compiled regex patterns.
+
+Patterns are compiled once per class and cached via ``_REGEX_CACHED``.
+Subclasses can override data constants (abbreviation sets, terminators, etc.)
+and the classmethod ``_compile_regex_dynamically`` will pick them up.
+
+<a id="yasbd.rules.base.Rules.apply"></a>
+
+#### apply
+
+```python
+def apply(text: str, preserve_quote_and_paren: bool) -> list[int]
+```
+
+Detect sentence boundaries in *text*.
 
 Two-pass algorithm:
-1\. Collect boundary candidates from punctuation positions\.
-2\. Remove false alarms \(mid-sentence abbreviations, ellipsis,
-   quote/paren spans, list markers\)\.
+1. Collect boundary candidates from punctuation positions.
+2. Remove false alarms (mid-sentence abbreviations, ellipsis,
+quote/paren spans, list markers).
 
-**Parameters:**
+**Arguments**:
 
-- **text**: A string to find sentence boundaries in\.
-- **preserve_quote_and_paren**: If \`\`True\`\`, suppress boundaries
-inside quote and parenthesis spans\.
+- `text` - A string to find sentence boundaries in.
+- `preserve_quote_and_paren` - If ``True``, suppress boundaries
+  inside quote and parenthesis spans.
+  
 
-**Returns:**
+**Returns**:
 
-- Sorted list of character offsets at which sentences end\.
-<a name="yasbd-rules-de"></a>
-## 🅼 yasbd\.rules\.de
+  Sorted list of character offsets at which sentences end.
 
-- **Classes:**
-  - 🅲 [DeRules](#yasbd-rules-de-DeRules)
+<a id="yasbd.rules.de"></a>
 
-### Classes
+# yasbd.rules.de
 
-<a name="yasbd-rules-de-DeRules"></a>
-### 🅲 yasbd\.rules\.de\.DeRules
+<a id="yasbd.rules.en"></a>
 
-```python
-class DeRules(Rules):
-```
-<a name="yasbd-rules-en"></a>
-## 🅼 yasbd\.rules\.en
+# yasbd.rules.en
 
-- **Classes:**
-  - 🅲 [EnRules](#yasbd-rules-en-EnRules)
+<a id="yasbd.rules.es"></a>
 
-### Classes
+# yasbd.rules.es
 
-<a name="yasbd-rules-en-EnRules"></a>
-### 🅲 yasbd\.rules\.en\.EnRules
+<a id="yasbd.rules.fr"></a>
 
-```python
-class EnRules(Rules):
-```
-<a name="yasbd-rules-es"></a>
-## 🅼 yasbd\.rules\.es
+# yasbd.rules.fr
 
-- **Classes:**
-  - 🅲 [EsRules](#yasbd-rules-es-EsRules)
+<a id="yasbd.rules.ht"></a>
 
-### Classes
+# yasbd.rules.ht
 
-<a name="yasbd-rules-es-EsRules"></a>
-### 🅲 yasbd\.rules\.es\.EsRules
+<a id="yasbd.rules.ja"></a>
 
-```python
-class EsRules(Rules):
-```
-<a name="yasbd-rules-fr"></a>
-## 🅼 yasbd\.rules\.fr
+# yasbd.rules.ja
 
-- **Classes:**
-  - 🅲 [FrRules](#yasbd-rules-fr-FrRules)
+<a id="yasbd.rules.pt"></a>
 
-### Classes
+# yasbd.rules.pt
 
-<a name="yasbd-rules-fr-FrRules"></a>
-### 🅲 yasbd\.rules\.fr\.FrRules
+<a id="yasbd.rules.ru"></a>
+
+# yasbd.rules.ru
+
+<a id="yasbd.rules.zh"></a>
+
+# yasbd.rules.zh
+
+<a id="yasbd.utils"></a>
+
+# yasbd.utils
+
+<a id="yasbd.utils.cleaner"></a>
+
+# yasbd.utils.cleaner
+
+<a id="yasbd.utils.cleaner.StreamCleaner"></a>
+
+## StreamCleaner Objects
 
 ```python
-class FrRules(Rules):
-```
-<a name="yasbd-rules-ht"></a>
-## 🅼 yasbd\.rules\.ht
-
-- **Classes:**
-  - 🅲 [HtRules](#yasbd-rules-ht-HtRules)
-
-### Classes
-
-<a name="yasbd-rules-ht-HtRules"></a>
-### 🅲 yasbd\.rules\.ht\.HtRules
-
-```python
-class HtRules(Rules):
-```
-<a name="yasbd-rules-ja"></a>
-## 🅼 yasbd\.rules\.ja
-
-- **Classes:**
-  - 🅲 [JaRules](#yasbd-rules-ja-JaRules)
-
-### Classes
-
-<a name="yasbd-rules-ja-JaRules"></a>
-### 🅲 yasbd\.rules\.ja\.JaRules
-
-```python
-class JaRules(Rules):
-```
-<a name="yasbd-rules-pt"></a>
-## 🅼 yasbd\.rules\.pt
-
-- **Classes:**
-  - 🅲 [PtRules](#yasbd-rules-pt-PtRules)
-
-### Classes
-
-<a name="yasbd-rules-pt-PtRules"></a>
-### 🅲 yasbd\.rules\.pt\.PtRules
-
-```python
-class PtRules(Rules):
-```
-<a name="yasbd-rules-ru"></a>
-## 🅼 yasbd\.rules\.ru
-
-- **Classes:**
-  - 🅲 [RuRules](#yasbd-rules-ru-RuRules)
-
-### Classes
-
-<a name="yasbd-rules-ru-RuRules"></a>
-### 🅲 yasbd\.rules\.ru\.RuRules
-
-```python
-class RuRules(Rules):
-```
-<a name="yasbd-rules-zh"></a>
-## 🅼 yasbd\.rules\.zh
-
-- **Classes:**
-  - 🅲 [ZhRules](#yasbd-rules-zh-ZhRules)
-
-### Classes
-
-<a name="yasbd-rules-zh-ZhRules"></a>
-### 🅲 yasbd\.rules\.zh\.ZhRules
-
-```python
-class ZhRules(Rules):
-```
-<a name="yasbd-utils"></a>
-## 🅼 yasbd\.utils
-<a name="yasbd-utils-cleaner"></a>
-## 🅼 yasbd\.utils\.cleaner
-
-- **Constants:**
-  - 🆅 [PREFIXES](#yasbd-utils-cleaner-PREFIXES)
-  - 🆅 [HYPHENATED\_WORD\_FINDER](#yasbd-utils-cleaner-HYPHENATED_WORD_FINDER)
-  - 🆅 [HEADING\_OR\_LIST\_FINDER](#yasbd-utils-cleaner-HEADING_OR_LIST_FINDER)
-  - 🆅 [ARTIFACT\_FINDER](#yasbd-utils-cleaner-ARTIFACT_FINDER)
-  - 🆅 [MULTIPLE\_SPACES\_FINDER](#yasbd-utils-cleaner-MULTIPLE_SPACES_FINDER)
-  - 🆅 [PAGE\_FINDER](#yasbd-utils-cleaner-PAGE_FINDER)
-  - 🆅 [HTML\_TAGS\_FINDER](#yasbd-utils-cleaner-HTML_TAGS_FINDER)
-  - 🆅 [NEWLINE\_IN\_MIDDLE\_OF\_WORD\_FINDER](#yasbd-utils-cleaner-NEWLINE_IN_MIDDLE_OF_WORD_FINDER)
-  - 🆅 [NEWLINE\_FOLLOWED\_BY\_PERIOD\_FINDER](#yasbd-utils-cleaner-NEWLINE_FOLLOWED_BY_PERIOD_FINDER)
-  - 🆅 [NO\_SPACE\_BETWEEN\_SENTENCES\_FINDER](#yasbd-utils-cleaner-NO_SPACE_BETWEEN_SENTENCES_FINDER)
-  - 🆅 [CONSECUTIVE\_FORWARD\_SLASH\_FINDER](#yasbd-utils-cleaner-CONSECUTIVE_FORWARD_SLASH_FINDER)
-  - 🆅 [CLEANING\_PIPELINE](#yasbd-utils-cleaner-CLEANING_PIPELINE)
-- **Classes:**
-  - 🅲 [StreamCleaner](#yasbd-utils-cleaner-StreamCleaner)
-
-### Constants
-
-<a name="yasbd-utils-cleaner-PREFIXES"></a>
-### 🆅 yasbd\.utils\.cleaner\.PREFIXES
-
-```python
-PREFIXES = {'hyper', 'ultra', 'super', 'extra', 'semi', 'multi', 'pre', 'post', 'ex', 'cross', 'inter', 'trans', 'anti', 'counter', 'non', 'quasi', 'self', 'auto', 'cyber', 'techno', 'electro', 'high', 'low', 'open', 'closed', 'up', 'down', 'off', 'mid', 'vice'}
-```
-<a name="yasbd-utils-cleaner-HYPHENATED_WORD_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.HYPHENATED\_WORD\_FINDER
-
-```python
-HYPHENATED_WORD_FINDER = re2.compile(f'\n    (?<=[{_vowels_pattern}]\\p{{M}}?-)\\s+(?=[{_vowels_pattern}])|\n    (?<=(?:{_suffix_pattern})-)\\s|\n    (?<!(?:{_suffix_pattern}))-\\s|\n', re2.X)
-```
-<a name="yasbd-utils-cleaner-HEADING_OR_LIST_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.HEADING\_OR\_LIST\_FINDER
-
-```python
-HEADING_OR_LIST_FINDER = re2.compile('(?<=^\\s?(?:[-•*+]|[\\w\\d][.)]))\\s*\\n', re2.M)
-```
-<a name="yasbd-utils-cleaner-ARTIFACT_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.ARTIFACT\_FINDER
-
-```python
-ARTIFACT_FINDER = re.compile('^\\s*[-•*+=#\\/\\\\_⯀∎]\\s*$', re.M)
-```
-<a name="yasbd-utils-cleaner-MULTIPLE_SPACES_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.MULTIPLE\_SPACES\_FINDER
-
-```python
-MULTIPLE_SPACES_FINDER = re.compile('\\s{2,}')
-```
-<a name="yasbd-utils-cleaner-PAGE_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.PAGE\_FINDER
-
-```python
-PAGE_FINDER = re.compile('\n    ^\\s*(?:\n        Page\\ \\d+\\ of\\ \\d+|  # Match "Page X of Y"\n        -\\s*\\d+\\s*-|          # Match "- X -"\n        \\|\\s*Page\\ \\d+\\s*\\|   # Match "| Page X |"\n    )\\s*$\n    ', re.X | re.M)
-```
-<a name="yasbd-utils-cleaner-HTML_TAGS_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.HTML\_TAGS\_FINDER
-
-```python
-HTML_TAGS_FINDER = re.compile('\n    # Branch 1: Strip the tag AND its content\n    <(script|img|iframe|object|embed|style|code)[^>]*?>.*?</\\1>|\n\n    # Branch 2: Just strip the brackets except quick formatting\n    </?\\b[^libu][^>]*?>\n    ', re.X | re.I | re.S)
-```
-<a name="yasbd-utils-cleaner-NEWLINE_IN_MIDDLE_OF_WORD_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.NEWLINE\_IN\_MIDDLE\_OF\_WORD\_FINDER
-
-```python
-NEWLINE_IN_MIDDLE_OF_WORD_FINDER = re2.compile('(?<=\\b[a-zA-Z]{1,2})\\n')
-```
-<a name="yasbd-utils-cleaner-NEWLINE_FOLLOWED_BY_PERIOD_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.NEWLINE\_FOLLOWED\_BY\_PERIOD\_FINDER
-
-```python
-NEWLINE_FOLLOWED_BY_PERIOD_FINDER = re.compile('\\n(?=\\.(?=\\s))')
-```
-<a name="yasbd-utils-cleaner-NO_SPACE_BETWEEN_SENTENCES_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.NO\_SPACE\_BETWEEN\_SENTENCES\_FINDER
-
-```python
-NO_SPACE_BETWEEN_SENTENCES_FINDER = re.compile('(?<=\\w\\.)(?=[A-Z][a-z])')
-```
-<a name="yasbd-utils-cleaner-CONSECUTIVE_FORWARD_SLASH_FINDER"></a>
-### 🆅 yasbd\.utils\.cleaner\.CONSECUTIVE\_FORWARD\_SLASH\_FINDER
-
-```python
-CONSECUTIVE_FORWARD_SLASH_FINDER = re.compile('\\/{3}')
-```
-<a name="yasbd-utils-cleaner-CLEANING_PIPELINE"></a>
-### 🆅 yasbd\.utils\.cleaner\.CLEANING\_PIPELINE
-
-```python
-CLEANING_PIPELINE = {'fix_mojibake': ftfy.fix_text, 'fix_ocr_text': _clean_ocr_text, 'unwrap_htmls': lambda t: t if '<' not in t else HTML_TAGS_FINDER.sub('', t), 'normalize_slashes': lambda t: t if '///' not in t else CONSECUTIVE_FORWARD_SLASH_FINDER.sub('', t), 'normalize_spaces': lambda t: t if ' ' not in t else MULTIPLE_SPACES_FINDER.sub(' ', t)}
+class StreamCleaner(StreamCleanerStub)
 ```
 
-### Classes
+Normalize and clean noisy text by applying ``ftfy``, HTML sanitization,
+and various regex cleanup rules across paragraphs.
 
-<a name="yasbd-utils-cleaner-StreamCleaner"></a>
-### 🅲 yasbd\.utils\.cleaner\.StreamCleaner
+**Examples**:
+
+  >>> list(StreamCleaner("Hello <b>world</b>. How are you?"))
+  ['Hello <b>world</b>. How are you?']
+  >>> list(StreamCleaner("<script>alert('xss')</script>clean text"))
+  ['clean text']
+  >>> list(StreamCleaner("<b>Hello</b> world", steps_to_skip=["unwrap_htmls"]))
+  ['<b>Hello</b> world']
+  >>> list(StreamCleaner("Text with ///slashes"))
+  ['Text with slashes']
+  >>> list(StreamCleaner("W\nO\nR\nD"))
+  ['WORD']
+  >>> list(StreamCleaner("An hyphe-\nnated sentence"))
+  ['An hyphenated sentence']
+  >>> list(StreamCleaner("Don't be naï-\nve"))
+  ["Don't be naïve"]
+  >>> list(StreamCleaner(""))
+  []
+  >>> StreamCleaner("Hello world", steps_to_skip=["nothing"])
+  Traceback (most recent call last):
+  ...
+- `ValueError` - Invalid step(s) to skip: ...
+  >>> list(StreamCleaner("Hello™ world", extra_steps=[lambda t: t.replace("™", "")]))
+  ['Hello world']
+  >>> list(StreamCleaner("hello", extra_steps=[lambda t: 1/0]))
+  Traceback (most recent call last):
+  ...
+- `yasbd.exceptions.CleanStepError` - extra step '<lambda>' raised ZeroDivisionError (see above for details)
+
+<a id="yasbd.utils.cleaner.StreamCleaner.__init__"></a>
+
+#### \_\_init\_\_
 
 ```python
-class StreamCleaner(StreamCleanerStub):
+@validate_input
+def __init__(source: str | TextIOBase,
+             steps_to_skip: Collection[str] | None = None,
+             extra_steps: Collection[Callable[[str], str]] | None = None,
+             *,
+             verbose: bool = False) -> None
 ```
 
-Normalize and clean noisy text by applying \`\`ftfy\`\`, HTML sanitization,
+Implements the iterator protocol. Yields cleaned paragraph strings.
 
-and various regex cleanup rules across paragraphs\.
+**Arguments**:
 
-**Functions:**
+- `source` - Plain text string or open text stream (e.g., ``StringIO``).
+- `steps_to_skip` - A collection of steps to ignore. All steps will run if not provided.
+  choices are:
+  - fix_mojibake
+  - fix_ocr_text
+  - unwrap_htmls
+  - normalize_slashes
+  - normalize_spaces
+- `extra_steps` - Optional user-defined cleaning functions, run after built-in steps.
+  Each function must accept and return ``str``.
+- `verbose` - Enable verbose logging.
 
-<a name="yasbd-utils-cleaner-StreamCleaner-__init__"></a>
-#### 🅵 yasbd\.utils\.cleaner\.StreamCleaner\.\_\_init\_\_
+<a id="yasbd.utils.input_validator"></a>
 
-```python
-def __init__(self, source: str | TextIOBase, steps_to_skip: Collection[str] | None = None) -> None:
-```
+# yasbd.utils.input\_validator
 
-Implements the iterator protocol\. Yields cleaned paragraph strings\.
+<a id="yasbd.utils.input_validator.validate_input"></a>
 
-**Parameters:**
-
-- **source**: Plain text string or open text stream \(e\.g\., \`\`StringIO\`\`\)\.
-- **steps_to_skip**: A collection of steps to ignore\. All steps will run if not provided\.
-choices are:
-- fix\_mojibake
-- fix\_ocr\_text
-- unwrap\_htmls
-- normalize\_slashes
-- normalize\_spaces
-<a name="yasbd-utils-cleaner-StreamCleaner-__iter__"></a>
-#### 🅵 yasbd\.utils\.cleaner\.StreamCleaner\.\_\_iter\_\_
+#### validate\_input
 
 ```python
-def __iter__(self) -> Iterator[str]:
-```
-<a name="yasbd-utils-cleaner-StreamCleaner-__next__"></a>
-#### 🅵 yasbd\.utils\.cleaner\.StreamCleaner\.\_\_next\_\_
-
-```python
-def __next__(self) -> str:
-```
-<a name="yasbd-utils-cleaner_stub"></a>
-## 🅼 yasbd\.utils\.cleaner\_stub
-
-- **Classes:**
-  - 🅲 [StreamCleanerStub](#yasbd-utils-cleaner_stub-StreamCleanerStub)
-
-### Classes
-
-<a name="yasbd-utils-cleaner_stub-StreamCleanerStub"></a>
-### 🅲 yasbd\.utils\.cleaner\_stub\.StreamCleanerStub
-
-```python
-class StreamCleanerStub:
-```
-
-Runtime validation and type marker for StreamCleaner-like inputs\.
-
-Used as a lightweight contract anchor for runtime checks and type hints
-where Protocols are not supported by the validation system\.
-
-This class provides no functionality\.
-<a name="yasbd-utils-input_validator"></a>
-## 🅼 yasbd\.utils\.input\_validator
-
-- **Functions:**
-  - 🅵 [validate\_input](#yasbd-utils-input_validator-validate_input)
-
-### Functions
-
-<a name="yasbd-utils-input_validator-validate_input"></a>
-### 🅵 yasbd\.utils\.input\_validator\.validate\_input
-
-```python
-def validate_input(fn):
+def validate_input(fn)
 ```
 
 A decorator that validates function inputs and outputs
 
-A wrapper around Pydantic's \`validate\_call\` that catches \`ValidationError\`
-and re-raises it as a more user-friendly \`InvalidInputError\`\.
-<a name="yasbd-utils-paragraph_stream"></a>
-## 🅼 yasbd\.utils\.paragraph\_stream
+A wrapper around Pydantic's `validate_call` that catches `ValidationError`
+and re-raises it as a more user-friendly `InvalidInputError`.
 
-- **Classes:**
-  - 🅲 [ParagraphStream](#yasbd-utils-paragraph_stream-ParagraphStream)
+<a id="yasbd.utils.logger"></a>
 
-### Classes
+# yasbd.utils.logger
 
-<a name="yasbd-utils-paragraph_stream-ParagraphStream"></a>
-### 🅲 yasbd\.utils\.paragraph\_stream\.ParagraphStream
+<a id="yasbd.utils.logger.log_info"></a>
+
+#### log\_info
 
 ```python
-class ParagraphStream:
+def log_info(verbose: bool, *args, **kwargs) -> None
 ```
 
-An iterator that groups lines of text into paragraph blocks\.
+Log an info message if verbose is enabled.
 
-This class implements Python's Iterator Protocol \(\_\_iter\_\_ and \_\_next\_\_\),
-retaining state across calls and yielding reconstructed paragraph blocks\.
+This is a convenience function that only logs when verbose mode is enabled,
+avoiding unnecessary log output in production.
 
-**Functions:**
+**Arguments**:
 
-<a name="yasbd-utils-paragraph_stream-ParagraphStream-__init__"></a>
-#### 🅵 yasbd\.utils\.paragraph\_stream\.ParagraphStream\.\_\_init\_\_
+- `verbose` - If True, logs the message; if False, does nothing.
+- `*args` - Positional arguments passed to logger.info().
+- `**kwargs` - Keyword arguments passed to logger.info().
+  
+
+**Example**:
+
+  >>> log_info(True, "hello {}", "world")
+  >>> log_info(False, "This will not be logged")
+
+<a id="yasbd.utils.paragraph_stream"></a>
+
+# yasbd.utils.paragraph\_stream
+
+<a id="yasbd.utils.paragraph_stream.ParagraphStream"></a>
+
+## ParagraphStream Objects
 
 ```python
-def __init__(self, source: 'str | TextIOBase | StreamCleaner', skip_empty_lines: bool = False) -> None:
+class ParagraphStream()
 ```
 
-Initialize ParagraphStream\.
+An iterator that groups lines of text into paragraph blocks.
 
-**Parameters:**
+This class implements Python's Iterator Protocol (__iter__ and __next__),
+retaining state across calls and yielding reconstructed paragraph blocks.
 
-- **source**: Input text as a string, \`\`TextIOBase\`\` stream, or \`\`StreamCleaner\`\`\.
-- **skip_empty_lines**: If True, blank separator lines are omitted from paragraph blocks\.
-<a name="yasbd-utils-paragraph_stream-ParagraphStream-__iter__"></a>
-#### 🅵 yasbd\.utils\.paragraph\_stream\.ParagraphStream\.\_\_iter\_\_
+**Examples**:
+
+  >>> streamer = ParagraphStream('Hello\n\nWorld', skip_empty_lines=False)
+  >>> list(streamer)
+  ['Hello\n\n', 'World']
+  
+  >>> streamer = ParagraphStream('Hello\n\nWorld', skip_empty_lines=True)
+  >>> list(streamer)
+  ['Hello\n', 'World']
+
+<a id="yasbd.utils.paragraph_stream.ParagraphStream.__init__"></a>
+
+#### \_\_init\_\_
 
 ```python
-def __iter__(self) -> Iterator[str]:
+def __init__(source: "str | TextIOBase | StreamCleaner",
+             skip_empty_lines: bool = False) -> None
 ```
-<a name="yasbd-utils-paragraph_stream-ParagraphStream-__next__"></a>
-#### 🅵 yasbd\.utils\.paragraph\_stream\.ParagraphStream\.\_\_next\_\_
+
+Initialize ParagraphStream.
+
+**Arguments**:
+
+- `source` - Input text as a string, ``TextIOBase`` stream, or ``StreamCleaner``.
+- `skip_empty_lines` - If True, blank separator lines are omitted from paragraph blocks.
+
+<a id="yasbd.utils.paragraph_stream.ParagraphStream.__next__"></a>
+
+#### \_\_next\_\_
 
 ```python
-def __next__(self) -> str:
+def __next__() -> str
 ```
 
-Advance the stream and return the next paragraph\.
+Advance the stream and return the next paragraph.
 
-Yields paragraphs reconstructed as strings, preserving original line endings\.
+Yields paragraphs reconstructed as strings, preserving original line endings.
 
-**Returns:**
+**Returns**:
 
-- The next complete paragraph string\.
+  The next complete paragraph string.
+  
 
-**Raises:**
+**Raises**:
 
-- **StopIteration**: When there are no more paragraphs to return\.
-<a name="yasbd-utils-pysbd_adapter"></a>
-## 🅼 yasbd\.utils\.pysbd\_adapter
+- `StopIteration` - When there are no more paragraphs to return.
 
-- **Classes:**
-  - 🅲 [TextSpan](#yasbd-utils-pysbd_adapter-TextSpan)
-  - 🅲 [Segmenter](#yasbd-utils-pysbd_adapter-Segmenter)
+<a id="yasbd.utils.pysbd_adapter"></a>
 
-### Classes
+# yasbd.utils.pysbd\_adapter
 
-<a name="yasbd-utils-pysbd_adapter-TextSpan"></a>
-### 🅲 yasbd\.utils\.pysbd\_adapter\.TextSpan
+<a id="yasbd.utils.pysbd_adapter.TextSpan"></a>
+
+## TextSpan Objects
 
 ```python
-class TextSpan:
+class TextSpan()
 ```
 
-A sentence with its character-offset span in the original text\.
+A sentence with its character-offset span in the original text.
 
-**Parameters:**
+**Arguments**:
 
-- **sent**: Sentence text\.
-- **start**: Start character offset of a sentence in original text\.
-- **end**: End character offset of a sentence in original text\.
+- `sent` - Sentence text.
+- `start` - Start character offset of a sentence in original text.
+- `end` - End character offset of a sentence in original text.
 
-**Functions:**
+<a id="yasbd.utils.pysbd_adapter.Segmenter"></a>
 
-<a name="yasbd-utils-pysbd_adapter-TextSpan-__init__"></a>
-#### 🅵 yasbd\.utils\.pysbd\_adapter\.TextSpan\.\_\_init\_\_
+## Segmenter Objects
 
 ```python
-def __init__(self, sent, start, end):
+class Segmenter()
 ```
-<a name="yasbd-utils-pysbd_adapter-TextSpan-__str__"></a>
-#### 🅵 yasbd\.utils\.pysbd\_adapter\.TextSpan\.\_\_str\_\_
+
+<a id="yasbd.utils.pysbd_adapter.Segmenter.__init__"></a>
+
+#### \_\_init\_\_
 
 ```python
-def __str__(self) -> str:
+@validate_input
+def __init__(language: str = "en",
+             clean: bool = False,
+             doc_type: str | None = None,
+             char_span: bool = False)
 ```
-<a name="yasbd-utils-pysbd_adapter-TextSpan-__eq__"></a>
-#### 🅵 yasbd\.utils\.pysbd\_adapter\.TextSpan\.\_\_eq\_\_
+
+Initializes the Segmenter.
+
+**Arguments**:
+
+- `language` - Two-character ISO 639-1 language code. Defaults to "en".
+- `clean` - Whether to clean the original text. Defaults to False.
+- `doc_type` - Normal text or OCRed text (e.g. "pdf"). Defaults to None.
+- `char_span` - Whether to return character offset spans. Defaults to False.
+
+<a id="yasbd.utils.pysbd_adapter.Segmenter.sentences_with_char_spans"></a>
+
+#### sentences\_with\_char\_spans
 
 ```python
-def __eq__(self, other) -> bool:
-```
-<a name="yasbd-utils-pysbd_adapter-Segmenter"></a>
-### 🅲 yasbd\.utils\.pysbd\_adapter\.Segmenter
-
-```python
-class Segmenter:
+@validate_input
+def sentences_with_char_spans(sentences: list[str]) -> list[TextSpan]
 ```
 
-**Functions:**
-
-<a name="yasbd-utils-pysbd_adapter-Segmenter-__init__"></a>
-#### 🅵 yasbd\.utils\.pysbd\_adapter\.Segmenter\.\_\_init\_\_
-
-```python
-def __init__(self, language: str = 'en', clean: bool = False, doc_type: str | None = None, char_span: bool = False):
-```
-
-Initializes the Segmenter\.
-
-**Parameters:**
-
-- **language** (default: `"en"`): Two-character ISO 639-1 language code\. Defaults to "en"\.
-- **clean** (default: `False`): Whether to clean the original text\. Defaults to False\.
-- **doc_type** (default: `None`): Normal text or OCRed text \(e\.g\. "pdf"\)\. Defaults to None\.
-- **char_span** (default: `False`): Whether to return character offset spans\. Defaults to False\.
-<a name="yasbd-utils-pysbd_adapter-Segmenter-language"></a>
-#### 🅵 yasbd\.utils\.pysbd\_adapter\.Segmenter\.language
-
-```python
-def language(self) -> str:
-```
-<a name="yasbd-utils-pysbd_adapter-Segmenter-language"></a>
-#### 🅵 yasbd\.utils\.pysbd\_adapter\.Segmenter\.language
-
-```python
-def language(self, value: str):
-```
-<a name="yasbd-utils-pysbd_adapter-Segmenter-sentences_with_char_spans"></a>
-#### 🅵 yasbd\.utils\.pysbd\_adapter\.Segmenter\.sentences\_with\_char\_spans
-
-```python
-def sentences_with_char_spans(self, sentences: list[str]) -> list[TextSpan]:
-```
-
-Map sentences to their char offsets using cumulative lengths\.
+Map sentences to their char offsets using cumulative lengths.
 
 Pysbd compatibility method
-<a name="yasbd-utils-pysbd_adapter-Segmenter-segment"></a>
-#### 🅵 yasbd\.utils\.pysbd\_adapter\.Segmenter\.segment
+
+<a id="yasbd.utils.pysbd_adapter.Segmenter.segment"></a>
+
+#### segment
 
 ```python
-def segment(self, text: str) -> list[str | TextSpan]:
+@validate_input
+def segment(text: str) -> list[str | TextSpan]
 ```
 
-Segments \*text\* into sentences\.
+Segments *text* into sentences.
 
-**Parameters:**
+**Arguments**:
 
-- **text**: Raw text to be segmented into sentences\.
+- `text` - Raw text to be segmented into sentences.
+  
 
-**Returns:**
+**Returns**:
 
-- A list of sentences \(strings\) by default, or a list of TextSpan
-objects if \`\`char\_span\`\` was set to \`\`True\`\`\.
+  A list of sentences (strings) by default, or a list of TextSpan
+  objects if ``char_span`` was set to ``True``.
+

--- a/API_REFERENCES.md
+++ b/API_REFERENCES.md
@@ -99,7 +99,7 @@ Initialize the segmenter.
 def lang() -> str
 ```
 
-ISO language code of the active rule set.
+ISO language code of the active rule set. This property is settable at runtime via `detector.lang = 'xx'` to switch the active language rules dynamically.
 
 <a id="yasbd.boundary_detector.BoundaryDetector.detect"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **English `TITLE_ABBRVS`**: Excluded `min` to prevent false split suppression (minute/minimum should not suppress sentence boundaries).
 
 ### Changed
+- **API doc generation** ([#83](https://github.com/speedyk-005/yasbd-lib/pull/83)): Replaced `python_docstring_markdown` with `pydoc-markdown`, fixing broken anchor links for re-exported symbols. Added `scripts/gen_api_docs.sh` for easy regeneration.
 - **`log_info` helper**: Extracted to `yasbd.utils.logger` — gated logging without repeating `if verbose:`.
 - **Unsupported language error messages** ([#78](https://github.com/speedyk-005/yasbd-lib/pull/78)): now list supported codes and suggest close matches (e.g. `eng` => `en`).
 - **Variable renames for clarity**:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ If you changed any docstrings or public interfaces, regenerate the docs:
 uv pip install -e ".[dev]"
 
 # Generate API_REFERENCES.md from docstrings
-uv run python -m python_docstring_markdown ./src/yasbd API_REFERENCES.md
+bash scripts/gen_api_docs.sh
 
 # Generate/update README TOC (GitHub-compatible)
 npx doctoc --github README.md

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Both methods accept plain strings, open text streams (TextIOBase), or a StreamCl
 
 #### Boundary detection
 
-[`detect()`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd-boundary_detector-BoundaryDetector-detect) tells you where each sentence stops. Integer offsets into the original input stream.
+[`detect()`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.boundary_detector.BoundaryDetector.detect) tells you where each sentence stops. Integer offsets into the original input stream.
 
 Two detection modes:
 
@@ -241,7 +241,7 @@ print(res)
 
 #### Segmentation
 
-If you do not want to manage boundary offsets yourself (and who would?), [`segment()`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd-boundary_detector-BoundaryDetector-segment) slices text for you.
+If you do not want to manage boundary offsets yourself (and who would?), [`segment()`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.boundary_detector.BoundaryDetector.segment) slices text for you.
 
 ```python
 detector.lang = "en"
@@ -261,7 +261,7 @@ print(res)
 ```
 
 > [!TIP]
-> **ParagraphStream** — yasbd uses [`ParagraphStream`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd-utils-paragraph_stream-ParagraphStream) internally to split text into paragraph blocks. You can import it directly if you need paragraph-level processing in your own code:
+> **ParagraphStream** — yasbd uses [`ParagraphStream`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.utils.paragraph_stream.ParagraphStream) internally to split text into paragraph blocks. You can import it directly if you need paragraph-level processing in your own code:
 > ```python
 > from yasbd.utils.paragraph_stream import ParagraphStream
 >
@@ -396,7 +396,7 @@ yasbd detect --help
 yasbd clean --help
 ```
 
-CLI API reference at [`API_REFERENCES.md#yasbd-cli`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd-cli).
+CLI API reference at [`API_REFERENCES.md#yasbd.cli`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.cli).
 
 #### About JSONL
 
@@ -420,7 +420,7 @@ print(res)
 # ['田中さんは「準備は完了しました」そう言って部屋を出た。', 'Ｕ．Ｓ．Ａ．の経済政策は非常に複雑です。']
 ```
 
-Same API surface. Same [`Segmenter`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd-utils-pysbd_adapter-Segmenter) class. Same [`segment()`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd-utils-pysbd_adapter-Segmenter-segment) method signature.
+Same API surface. Same [`Segmenter`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.utils.pysbd_adapter.Segmenter) class. Same [`segment()`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.utils.pysbd_adapter.Segmenter.segment) method signature.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
   "pytest>=8.3.5",
   "pytest-cov>=6.2.1",
   "pre-commit>=4.4.0",
-  "python-docstring-markdown>=0.2.2",
+  "pydoc-markdown>=4.8.0,<5.0",
   "ruff>=0.14.14",
 ] 
 

--- a/scripts/gen_api_docs.sh
+++ b/scripts/gen_api_docs.sh
@@ -24,5 +24,5 @@ done
 
 export PYTHONPATH="$REPO_DIR/src"
 OUT="$REPO_DIR/API_REFERENCES.md"
-pydoc-markdown "${ARGS[@]}" --render-toc > "$OUT" 2>/dev/null
+pydoc-markdown "${ARGS[@]}" --render-toc > "$OUT"
 echo "Done. Wrote $OUT ($(wc -l < "$OUT") lines)"

--- a/scripts/gen_api_docs.sh
+++ b/scripts/gen_api_docs.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Generate API_REFERENCES.md using pydoc-markdown.
+# Auto-discovers all yasbd modules, skipping private/irrelevant stubs.
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")"/.. && pwd)"
+cd "$REPO_DIR"
+
+MODULES=$(find src/yasbd -name '*.py' \
+    ! -name '_template.py' \
+    ! -name 'cleaner_stub.py' \
+    | sort \
+    | sed \
+        -e 's|^src/||' \
+        -e 's|/|.|g' \
+        -e 's|\.py$||' \
+        -e 's|\.__init__$||'
+)
+
+ARGS=()
+for mod in $MODULES; do
+    ARGS+=(-m "$mod")
+done
+
+export PYTHONPATH="$REPO_DIR/src"
+OUT="$REPO_DIR/API_REFERENCES.md"
+pydoc-markdown "${ARGS[@]}" --render-toc > "$OUT" 2>/dev/null
+echo "Done. Wrote $OUT ($(wc -l < "$OUT") lines)"


### PR DESCRIPTION
Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * API reference reorganized for a clearer layout, normalized method/property descriptions, and simplified adapter/paragraph docs.
  * CLI docs now document a repeatable “extra step” option; cleaner docs mention extra steps and a new CleanStepError.
  * README anchors updated for more reliable API links; changelog updated to note the docs-generator change.

* **Chores**
  * Documentation generation workflow switched and a regeneration script added; dev dependency for the doc generator updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->