### PR TITLE
Expose utils submodules at package root level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`CleanStepError`**: Raised when an extra step fails or returns non-string.
 - **CLI short flags**: `-w` for `--preserve-whitespace`, `-r` for `--relative`.
 - **Custom exception classes**: `YasbdError` (base), `UnsupportedLanguageError`, and `InvalidInputError` with ValueError/TypeError mixins.
+- **Flat utils imports** ([#84](https://github.com/speedyk-005/yasbd-lib/pull/84)): Utils submodules now importable at package root via `__path__` extension — `from yasbd.cleaner import StreamCleaner` as an alternative to `from yasbd.utils.cleaner import StreamCleaner`.
 - **Radicli-based CLI** ([#79](https://github.com/speedyk-005/yasbd-lib/pull/79)): `segment`, `detect`, `clean`, and `langs` subcommands with auto-stdin detection, JSONL output, and ~3.3x faster startup vs typer.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ print(res)
 > [!TIP]
 > **ParagraphStream** — yasbd uses [`ParagraphStream`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd-utils-paragraph_stream-ParagraphStream) internally to split text into paragraph blocks. You can import it directly if you need paragraph-level processing in your own code:
 > ```python
-> from yasbd.utils.paragraph_stream import ParagraphStream
+> from yasbd.utils.paragraph_stream import ParagraphStream  # or yasbd.paragraph_stream
 >
 > for para in ParagraphStream(text):  # or an opened file
 >     print(para)  # each paragraph block
@@ -277,7 +277,7 @@ StreamCleaner accepts either a string or an open text stream and yields cleaned 
 You can pass a "StreamCleaner" instance directly to "detect()" or "segment()" to clean text as it is processed.
 
 ```python
-from yasbd.utils.cleaner import StreamCleaner
+from yasbd.utils.cleaner import StreamCleaner  # or yasbd.cleaner
 
 cleaner = StreamCleaner(
     "Hello  world.   This is  messy.",
@@ -290,7 +290,7 @@ list(cleaner)
 "StreamCleaner" implements the iterator protocol and yields cleaned paragraphs one at a time. It can consume plain strings, open text files, and other text streams.
 
 ```python
-from yasbd.utils.cleaner import StreamCleaner
+from yasbd.utils.cleaner import StreamCleaner  # or yasbd.cleaner
 
 with open("document.txt", encoding="utf-8") as f:
     for paragraph in StreamCleaner(f):
@@ -412,7 +412,7 @@ Migrating from pysbd? Swap the import and keep your pipeline:
 
 ```python
 # Before: from pysbd import Segmenter
-from yasbd.utils.pysbd_adapter import Segmenter
+from yasbd.utils.pysbd_adapter import Segmenter  # or yasbd.pysbd_adapter
 
 seg = Segmenter(language="ja")
 res = seg.segment('田中さんは「準備は完了しました」そう言って部屋を出た。Ｕ．Ｓ．Ａ．の経済政策は非常に複雑です。')

--- a/src/yasbd/__init__.py
+++ b/src/yasbd/__init__.py
@@ -1,4 +1,5 @@
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
 from yasbd.boundary_detector import BoundaryDetector
 from yasbd.boundary_detector import ParagraphEOF
@@ -12,6 +13,14 @@ try:
     __version__ = version("yasbd-lib")
 except PackageNotFoundError:
     __version__ = "unknown"
+
+# Expose utils submodules at package root level so both
+#   from yasbd.utils.cleaner import StreamCleaner   (legacy)
+#   from yasbd.cleaner import StreamCleaner          (flat)
+# work without changing the physical file layout.
+_utils_path = str(Path(__file__).parent / "utils")
+if _utils_path not in __path__:
+    __path__.append(_utils_path)
 
 __all__ = [
     "BoundaryDetector",


### PR DESCRIPTION
Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Helper/util classes can now be imported via simplified alternative top-level paths.

* **Documentation**
  * README updated with usage examples showing the new import options alongside existing ones.
  * CHANGELOG updated to document the new flat import option for utils.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->