### PR TITLE
Add auto language detection to BoundaryDetector  (default)   

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0] - Unreleased
+
+### Added
+- **Automatic language detection** ([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)): `BoundaryDetector(lang="auto")` detects language from text on first paragraph via py3langid. Logs warning on confidence < 0.8.
+- **`classify_language` utility**([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)): Wraps py3langid with softmax normalization and preference for supported languages.
+
+### Changed
+- **Internal refactors** ([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)):
+  - Cached up to 5 rule objects, evicting least recently used on overflow.
+  - Moved `load_rule` cause rule loading belongs to the rules package, not the detector.
+  - Restructured `detect()` loop with first paragraph peeked before loop, uses `chain()` to rejoin — cleaner separation of EOF logic from content processing.
+
 ## [0.4.0] - 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Automatic language detection** ([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)): `BoundaryDetector(lang="auto")` detects language from text on first paragraph via py3langid. Logs warning on confidence < 0.8.
-- **`classify_language` utility**([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)): Wraps py3langid with softmax normalization and preference for supported languages.
+- **`classify_language` utility** ([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)): Wraps py3langid with softmax normalization and preference for supported languages.
 
 ### Changed
 - **Internal refactors** ([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)):
   - Cached up to 5 rule objects, evicting least recently used on overflow.
-  - Moved `load_rule` cause rule loading belongs to the rules package, not the detector.
+  - Moved `load_rule` because rule loading belongs to the rules package, not the detector.
   - Restructured `detect()` loop with first paragraph peeked before loop, uses `chain()` to rejoin — cleaner separation of EOF logic from content processing.
 
 ## [0.4.0] - 2026-06-10

--- a/README.md
+++ b/README.md
@@ -181,13 +181,13 @@ from yasbd.boundary_detector import BoundaryDetector
 # Or from yasbd import BoundaryDetector
 
 # Basic setup
-detector = BoundaryDetector(lang="en")
+detector = BoundaryDetector()
 
 # With all options (so far.)
 detector = BoundaryDetector(
-	# ISO 639 code (e.g., en, fr, es, ...). Defaults to `en`.
+	# ISO 639 code (e.g., en, fr, es, ...). Defaults to "auto".
 	# https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
-    lang="fr",  # Default to "auto"
+    lang="fr",
 
     # Don't split inside them. (It won't protect block quotes) Defaults to `True`.
     # https://en.wikipedia.org/wiki/Block_quotation

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ detector = BoundaryDetector(lang="en")
 detector = BoundaryDetector(
 	# ISO 639 code (e.g., en, fr, es, ...). Defaults to `en`.
 	# https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
-    lang="fr",
+    lang="fr",  # Default to "auto"
 
     # Don't split inside them. (It won't protect block quotes) Defaults to `True`.
     # https://en.wikipedia.org/wiki/Block_quotation
@@ -205,6 +205,12 @@ detector.lang = "es"
 ```
 
 The rule module loads lazily on first access. Switching mid-stream reimports the module and rebinds the pattern cache. Zero config, no restarts needed.
+
+> [!TIP]
+> **Auto-detect**
+>
+> Keep lang="auto" if you want the system to figure out the language for you.
+> I wouldn’t lean on it too hard tho — it’s a bit slower, and short phrases can throw it off sometimes.
 
 ### Core Methods
 The two primary APIs are detect() and segment().
@@ -431,7 +437,7 @@ Same API surface. Same [`Segmenter`](https://github.com/speedyk-005/yasbd-lib/bl
 - [x] Drop-in pysbd adapter (same API, no pipeline changes)
 - [x] StreamCleaner for OCR'd and noisy text
 - [x] CLI tool
-- [ ] Automatic language detection with caching (#74)
+- [x] Automatic language detection with caching (#74)
 - [ ] spaCy v3 pipeline component factory (#28)
 - [ ] 22+ language targets (#20)
 - [ ] REST API for remote boundary detection *(stretch)*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "ftfy>=6.2.0,<7.0",
   "pydantic>=2.11.0,<3.0",
   "retrie>=0.3.0,<1.0",
+  "py3langid>=0.2.2,<1.0",
   "radicli>=0.0.25,<1.0",
 ]
 

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -1,11 +1,8 @@
-import difflib
 from collections.abc import Generator, Iterable
-from importlib import import_module
 from io import TextIOBase
 from itertools import tee
 
-from yasbd.exceptions import UnsupportedLanguageError
-from yasbd.rules import get_supported_langs
+from yasbd.rules import load_rule
 from yasbd.utils.cleaner_stub import StreamCleanerStub
 from yasbd.utils.input_validator import validate_input
 from yasbd.utils.logger import log_info
@@ -63,22 +60,7 @@ class BoundaryDetector:
     def _load_rule(self, lang: str) -> None:
         """Dynamically import and instantiate the rule module for *lang*."""
         log_info(self.verbose, "Trying to load rule module for {}", lang)
-
-        try:
-            rule_module = import_module(f"yasbd.rules.{lang}")
-        except ModuleNotFoundError as e:
-            if lang not in str(e):
-                raise
-            supported = get_supported_langs()
-            msg = (
-                f"Unsupported language: {lang!r}\n\n"
-                f"Supported language codes:\n  {', '.join(supported)}"
-            )
-            if close := difflib.get_close_matches(lang, supported, n=3, cutoff=0.5):
-                msg += f"\n\n💡 Did you mean:\n  {', '.join(close)}"
-            raise UnsupportedLanguageError(msg) from None
-
-        self._rule = getattr(rule_module, f"{lang.capitalize()}Rules")()
+        self._rule = load_rule(lang)
 
     def _detect_relative_spans(
         self,

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -5,6 +5,7 @@ from itertools import tee, chain
 
 from yasbd.rules import load_rule
 from yasbd.utils.cleaner_stub import StreamCleanerStub
+from yasbd.utils.language_classifier import classify_language
 from yasbd.utils.input_validator import validate_input
 from yasbd.utils.logger import log_info
 from yasbd.utils.paragraph_stream import ParagraphStream
@@ -18,7 +19,7 @@ class BoundaryDetector:
     @validate_input
     def __init__(
         self,
-        lang: str = "en",
+        lang: str = "auto",
         *,
         preserve_quote_and_paren: bool = True,
         verbose: bool = False,
@@ -26,7 +27,8 @@ class BoundaryDetector:
         """Initialize the segmenter.
 
         Args:
-            lang: Two chars ISO language code (e.g. en, fr, ...).
+            lang: Two chars ISO language code (e.g. en, fr, ...) or "auto"
+                to detect language from text.
             preserve_quote_and_paren: Do not split on terminators inside
                 quoted or parenthesised text.
             verbose: Enable verbose logging.
@@ -55,12 +57,31 @@ class BoundaryDetector:
         if lang == old_lang:
             return
 
+        if lang == "auto":
+            self._lang = "auto"
+            log_info(self.verbose, "Language set to auto-detection")
+            return
+
         self._get_rule(lang)  # warm cache
         self._lang = lang
         log_info(self.verbose, "Language switched from {} to {}", old_lang, self._lang)
 
-    def _get_rule(self, lang: str) -> object:
-        """Return the rule object for *lang*, using a 5-entry LRU cache."""
+    def _get_rule(self, lang: str, snippet: str = "") -> object:
+        """Return the rule object for *lang*, using a 5-entry LRU cache.
+
+        When *lang* is ``"auto"``, language is detected from *snippet*
+        using :func:`classify_language`.
+        """
+        if lang == "auto":
+            lang, confidence = classify_language(snippet)
+            if confidence < 0.8:
+                log_info(
+                    self.verbose,
+                    "Low confidence ({:.2f}) for detected lang {!r} in auto mode",
+                    confidence,
+                    lang,
+                )
+
         if lang in self._rule_cache:
             self._rule_cache.move_to_end(lang)
             return self._rule_cache[lang]
@@ -75,8 +96,10 @@ class BoundaryDetector:
         para_iter: Iterable[str],
     ) -> Generator[tuple[int, int], None, None]:
         """Yield per-paragraph sentence spans."""
-        rule = self._get_rule(self._lang)
-        for para in para_iter:
+        first_para = next(para_iter, "")
+        rule = self._get_rule(self._lang, first_para)
+
+        for para in chain([first_para], para_iter):
             if not para or para.isspace():
                 boundaries = [0, len(para)]
             else:
@@ -112,7 +135,6 @@ class BoundaryDetector:
         Yields:
             Integer boundary offsets or ``ParagraphEOF`` sentinels.
         """
-
         log_info(
             self.verbose,
             "Called with type={}, relative={}",
@@ -125,13 +147,13 @@ class BoundaryDetector:
         )
 
         offset = 0
-        rule = self._get_rule(self._lang)
-
         # Handle first para differently
         is_first_para = True
         first_para = next(para_iter, "")
         if relative and first_para.isspace():
             yield ParagraphEOF
+   
+        rule = self._get_rule(self._lang, first_para)
 
         for para in chain([first_para], para_iter):
             if para.isspace():

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -27,8 +27,8 @@ class BoundaryDetector:
         """Initialize the segmenter.
 
         Args:
-            lang: Two chars ISO language code (e.g. en, fr, ...) or "auto"
-                to detect language from text.
+            lang: Two chars ISO language code (e.g., 'en', 'fr', ...).
+                Defaults to 'auto'
             preserve_quote_and_paren: Do not split on terminators inside
                 quoted or parenthesised text.
             verbose: Enable verbose logging.

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
 from collections.abc import Generator, Iterable
 from io import TextIOBase
-from itertools import tee, chain
+from itertools import chain, tee
 
 from yasbd.rules import load_rule
 from yasbd.utils.cleaner_stub import StreamCleanerStub
-from yasbd.utils.language_classifier import classify_language
 from yasbd.utils.input_validator import validate_input
+from yasbd.utils.language_classifier import classify_language
 from yasbd.utils.logger import log_info
 from yasbd.utils.paragraph_stream import ParagraphStream
 
@@ -152,7 +152,7 @@ class BoundaryDetector:
         first_para = next(para_iter, "")
         if relative and first_para.isspace():
             yield ParagraphEOF
-   
+
         rule = self._get_rule(self._lang, first_para)
 
         for para in chain([first_para], para_iter):

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from collections.abc import Generator, Iterable
 from io import TextIOBase
 from itertools import tee
@@ -32,6 +33,7 @@ class BoundaryDetector:
         """
         self.preserve_quote_and_paren = preserve_quote_and_paren
         self.verbose = verbose
+        self._rule_cache: OrderedDict[str, object] = OrderedDict()
         self.lang = lang.lower()
         log_info(
             self.verbose,
@@ -53,25 +55,32 @@ class BoundaryDetector:
         if lang == old_lang:
             return
 
-        self._load_rule(lang)
+        self._get_rule(lang)  # warm cache
         self._lang = lang
         log_info(self.verbose, "Language switched from {} to {}", old_lang, self._lang)
 
-    def _load_rule(self, lang: str) -> None:
-        """Dynamically import and instantiate the rule module for *lang*."""
-        log_info(self.verbose, "Trying to load rule module for {}", lang)
-        self._rule = load_rule(lang)
+    def _get_rule(self, lang: str) -> object:
+        """Return the rule object for *lang*, using a 5-entry LRU cache."""
+        if lang in self._rule_cache:
+            self._rule_cache.move_to_end(lang)
+            return self._rule_cache[lang]
+        rule = load_rule(lang)
+        self._rule_cache[lang] = rule
+        if len(self._rule_cache) > 5:
+            self._rule_cache.popitem(last=False)
+        return rule
 
     def _detect_relative_spans(
         self,
         para_iter: Iterable[str],
     ) -> Generator[tuple[int, int], None, None]:
         """Yield per-paragraph sentence spans."""
+        rule = self._get_rule(self._lang)
         for para in para_iter:
             if not para or para.isspace():
                 boundaries = [0, len(para)]
             else:
-                boundaries = self._rule.apply(para, self.preserve_quote_and_paren)
+                boundaries = rule.apply(para, self.preserve_quote_and_paren)
 
             for i in range(len(boundaries) - 1):
                 start = boundaries[i]
@@ -117,6 +126,7 @@ class BoundaryDetector:
 
         offset = 0
         is_first_pos = True
+        rule = self._get_rule(self._lang)
         for para in para_iter:
             is_space = para.isspace()
             if relative and (not is_first_pos or is_space):
@@ -125,7 +135,7 @@ class BoundaryDetector:
                     continue
             is_first_pos = False
 
-            boundaries = self._rule.apply(para.rstrip(), self.preserve_quote_and_paren)
+            boundaries = rule.apply(para.rstrip(), self.preserve_quote_and_paren)
 
             for pos in boundaries[1:]:
                 yield offset + pos if not relative else pos

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from collections.abc import Generator, Iterable
 from io import TextIOBase
-from itertools import tee
+from itertools import tee, chain
 
 from yasbd.rules import load_rule
 from yasbd.utils.cleaner_stub import StreamCleanerStub
@@ -125,15 +125,21 @@ class BoundaryDetector:
         )
 
         offset = 0
-        is_first_pos = True
         rule = self._get_rule(self._lang)
-        for para in para_iter:
-            is_space = para.isspace()
-            if relative and (not is_first_pos or is_space):
+
+        # Handle first para differently
+        is_first_para = True
+        first_para = next(para_iter, "")
+        if relative and first_para.isspace():
+            yield ParagraphEOF
+
+        for para in chain([first_para], para_iter):
+            if para.isspace():
+                continue
+
+            if relative and not is_first_para:
                 yield ParagraphEOF
-                if is_space:
-                    continue
-            is_first_pos = False
+            is_first_para = False
 
             boundaries = rule.apply(para.rstrip(), self.preserve_quote_and_paren)
 

--- a/src/yasbd/rules/__init__.py
+++ b/src/yasbd/rules/__init__.py
@@ -1,5 +1,9 @@
+import difflib
 from functools import cache
+from importlib import import_module
 from pathlib import Path
+
+from yasbd.exceptions import UnsupportedLanguageError
 
 
 @cache
@@ -13,3 +17,29 @@ def get_supported_langs() -> list[str]:
         if f.suffix == ".py":
             langs.append(f.stem)
     return sorted(langs)
+
+
+def load_rule(lang: str):
+    """Import and instantiate the rule module for *lang*.
+
+    Returns:
+        The instantiated rule object.
+
+    Raises:
+        UnsupportedLanguageError: If no rule module exists for *lang*.
+    """
+    try:
+        rule_module = import_module(f"yasbd.rules.{lang}")
+    except ModuleNotFoundError as e:
+        if lang not in str(e):
+            raise
+        supported = get_supported_langs()
+        msg = (
+            f"Unsupported language: {lang!r}\n\n"
+            f"Supported language codes:\n  {', '.join(supported)}"
+        )
+        if close := difflib.get_close_matches(lang, supported, n=3, cutoff=0.5):
+            msg += f"\n\n💡 Did you mean:\n  {', '.join(close)}"
+        raise UnsupportedLanguageError(msg) from None
+
+    return getattr(rule_module, f"{lang.capitalize()}Rules")()

--- a/src/yasbd/rules/__init__.py
+++ b/src/yasbd/rules/__init__.py
@@ -4,6 +4,7 @@ from importlib import import_module
 from pathlib import Path
 
 from yasbd.exceptions import UnsupportedLanguageError
+from yasbd.rules.base import Rules
 
 
 @cache
@@ -19,7 +20,7 @@ def get_supported_langs() -> list[str]:
     return sorted(langs)
 
 
-def load_rule(lang: str):
+def load_rule(lang: str) -> Rules:
     """Import and instantiate the rule module for *lang*.
 
     Returns:

--- a/src/yasbd/utils/language_classifier.py
+++ b/src/yasbd/utils/language_classifier.py
@@ -59,7 +59,7 @@ def classify_language(text: str) -> tuple[str, float]:
     ]
 
     if not candidates:
-        candidates = ranks
+        candidates = ranks  # pragma: no cover
 
     # -- Compute a numerically stable softmax. --
     max_score = max(score for _, score in candidates)
@@ -74,7 +74,7 @@ def classify_language(text: str) -> tuple[str, float]:
     return language, round(confidence, 2)
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     texts = [
         "Hello, how are you?",
         "¿Cómo estás?",

--- a/src/yasbd/utils/language_classifier.py
+++ b/src/yasbd/utils/language_classifier.py
@@ -38,7 +38,7 @@ def classify_language(text: str) -> tuple[str, float]:
             - The predicted ISO 639-1 language code.
             - A confidence score between 0.0 and 1.0.
 
-    Exemples:
+    Examples:
         >>> language, confidence = classify_language("kiyès ?")
         >>> language
         'ht'

--- a/src/yasbd/utils/language_classifier.py
+++ b/src/yasbd/utils/language_classifier.py
@@ -1,0 +1,98 @@
+import math
+from functools import lru_cache
+
+import py3langid as langid
+
+from yasbd.rules import get_supported_langs
+
+
+PREFERRED = get_supported_langs()
+TOP_K = 5
+
+# Maximum allowed log-score difference from the best candidate.
+# Larger values make the detector more willing to favor preferred languages.
+MAX_GAP = 15.0
+
+
+@lru_cache(maxsize=12)
+def classify_language(text: str) -> tuple[str, float]:
+    """Classify text with a preference for expected languages.
+
+    This function avoids the explicit ``py3langid.LanguageIdentifier`` initialization
+    and its associated cold-start cost by relying on this convenience API.
+
+    The algorithm works as follows:
+        1. Obtain the ranked language predictions.
+        2. Look for preferred languages within the top ``TOP_K`` results.
+        3. Only consider preferred languages whose score is within
+           ``MAX_GAP`` of the top prediction.
+        4. If no suitable preferred language is found, fall back to the
+           model's top prediction.
+        5. Compute a normalized confidence score using a softmax over the
+           selected candidates.
+
+    Args:
+        text: The text to classify.
+
+    Returns:
+        A tuple containing:
+            - The predicted ISO 639-1 language code.
+            - A confidence score between 0.0 and 1.0.
+
+    Exemples:
+        >>> language, confidence = classify_language("kiyès ?")
+        >>> language
+        'ht'
+        >>> 0.0 <= confidence <= 1.0
+        True
+
+    Raises:
+        ValueError: If the detector returns no language scores.
+    """
+    ranks = langid.rank(text)
+    _, top_score = ranks[0]
+
+    # Prefer expected languages if they are among the strongest candidates.
+    candidates = [
+        (language, score)
+        for language, score in ranks[:TOP_K]
+        if (
+            language in PREFERRED
+            and top_score - score <= MAX_GAP
+        )
+    ]
+
+    if not candidates:
+        candidates = ranks 
+
+    # -- Compute a numerically stable softmax. --
+    max_score = max(score for _, score in candidates)
+    total = sum(
+        math.exp(score - max_score)
+        for _, score in candidates
+    )
+
+    language, score = max(
+        candidates,
+        key=lambda item: item[1],
+    )
+    confidence = math.exp(score - max_score) / total
+
+    return language, round(confidence, 2)
+
+
+if __name__ == "__main__":
+    texts = [
+        "Hello, how are you?",
+        "¿Cómo estás?",
+        "Bonjour, comment allez-vous?",
+        "Guten Tag!",
+        "Привет!",
+        "مرحبا",
+        "こんにちは",
+        "你好",
+        "kiyès ?",
+    ]
+    for text in texts:
+        lang, conf = classify_language(text)
+        print(f"{lang} ({conf:.2f})  {text}")

--- a/src/yasbd/utils/language_classifier.py
+++ b/src/yasbd/utils/language_classifier.py
@@ -25,8 +25,8 @@ def classify_language(text: str) -> tuple[str, float]:
         2. Look for preferred languages within the top ``TOP_K`` results.
         3. Only consider preferred languages whose score is within
            ``MAX_GAP`` of the top prediction.
-        4. If no suitable preferred language is found, fall back to the
-           model's top prediction.
+        4. If no suitable preferred language is found, fall back to all
+           ranked candidates.
         5. Compute a normalized confidence score using a softmax over the
            selected candidates.
 
@@ -84,6 +84,7 @@ if __name__ == "__main__":
         "こんにちは",
         "你好",
         "kiyès ?",
+        "",
     ]
     for text in texts:
         lang, conf = classify_language(text)

--- a/src/yasbd/utils/language_classifier.py
+++ b/src/yasbd/utils/language_classifier.py
@@ -5,7 +5,6 @@ import py3langid as langid
 
 from yasbd.rules import get_supported_langs
 
-
 PREFERRED = get_supported_langs()
 TOP_K = 5
 
@@ -56,21 +55,15 @@ def classify_language(text: str) -> tuple[str, float]:
     candidates = [
         (language, score)
         for language, score in ranks[:TOP_K]
-        if (
-            language in PREFERRED
-            and top_score - score <= MAX_GAP
-        )
+        if (language in PREFERRED and top_score - score <= MAX_GAP)
     ]
 
     if not candidates:
-        candidates = ranks 
+        candidates = ranks
 
     # -- Compute a numerically stable softmax. --
     max_score = max(score for _, score in candidates)
-    total = sum(
-        math.exp(score - max_score)
-        for _, score in candidates
-    )
+    total = sum(math.exp(score - max_score) for _, score in candidates)
 
     language, score = max(
         candidates,
@@ -85,7 +78,6 @@ if __name__ == "__main__":
     texts = [
         "Hello, how are you?",
         "¿Cómo estás?",
-        "Bonjour, comment allez-vous?",
         "Guten Tag!",
         "Привет!",
         "مرحبا",

--- a/src/yasbd/utils/pysbd_adapter.py
+++ b/src/yasbd/utils/pysbd_adapter.py
@@ -42,7 +42,7 @@ class Segmenter:
     @validate_input
     def __init__(
         self,
-        language: str = "en",
+        language: str = "en",  # Match pysbd default
         clean: bool = False,
         doc_type: str | None = None,
         char_span: bool = False,

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -102,3 +102,27 @@ def test_detect_paragraph_eof_sentinel(en_detector):
     # Non-relative = no sentinels,
     result = list(en_detector.detect("First.\n\nSecond.", relative=False))
     assert result == [6, 15]
+
+
+def test_rule_cache_lru(en_detector):
+    """test that rule objects are cached (max 5) and reused on lang switch."""
+    # Same lang = same cached object
+    r1 = en_detector._get_rule("en")
+    r2 = en_detector._get_rule("en")
+    assert r1 is r2, "same lang should return cached rule"
+
+    # Different lang = different object
+    r_fr = en_detector._get_rule("fr")
+    assert r1 is not r_fr, "different lang should return different rule object"
+
+    # Switch back = cached
+    r3 = en_detector._get_rule("en")
+    assert r1 is r3, "switching back to cached lang should reuse cached rule"
+
+    # LRU eviction after 6 distinct langs
+    for lang in ["de", "es", "ht", "ar", "ja"]:
+        en_detector._get_rule(lang)
+    # 'en' was used first, then pushed out by 6 newer entries
+    r_en = en_detector._get_rule("en")
+    assert r_en is not r1, "en should have been evicted after 6 other langs"
+    assert type(r_en) is type(r1), "freshly loaded en rule should exist"  # type: ignore[unreachable]

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -119,10 +119,10 @@ def test_rule_cache_lru(en_detector):
     r3 = en_detector._get_rule("en")
     assert r1 is r3, "switching back to cached lang should reuse cached rule"
 
-    # LRU eviction after 6 distinct langs
+    # LRU eviction: load 5 more languages (cache capacity is 5)
     for lang in ["de", "es", "ht", "ar", "ja"]:
         en_detector._get_rule(lang)
-    # 'en' was used first, then pushed out by 6 newer entries
+    # 'en' was the first loaded, then pushed out by 5 newer entries
     r_en = en_detector._get_rule("en")
     assert r_en is not r1, "en should have been evicted after 6 other langs"
     assert type(r_en) is type(r1), "freshly loaded en rule should exist"  # type: ignore[unreachable]


### PR DESCRIPTION
Closes #74

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic language detection enabled by default (lang="auto") with per-language caching and confidence reporting.

* **Documentation**
  * README example and "Auto-detect" tip updated with performance notes for short phrases.
  * Changelog updated to document auto-detect and related improvements.

* **Tests**
  * Added unit test for language-rule caching and eviction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->