### PR TITLE
Expand NEWLINE_IN_MIDDLE_OF_WORD_FINDER to join  mid-word newlines across chunk boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cached up to 5 rule objects, evicting least recently used on overflow.
   - Moved `load_rule` because rule loading belongs to the rules package, not the detector.
   - Restructured `detect()` loop with first paragraph peeked before loop, uses `chain()` to rejoin — cleaner separation of EOF logic from content processing.
+- **`NEWLINE_IN_MIDDLE_OF_WORD_FINDER` renamed to `NEWLINE_BETWEEN_WORD_CHARS`** and expanded pattern from `(?<=\b[a-zA-Z]{1,2})\n` to `(?<=\w)\n(?=\w)` to join mid-word newlines at any word-character boundary.
 
 ## [0.4.0] - 2026-06-10
 

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -68,7 +68,7 @@ HTML_TAGS_FINDER = re.compile(
 # -- Regex ported from pysbd --
 
 # https://regex101.com/r/0dTHBO/3/substitution
-NEWLINE_IN_MIDDLE_OF_WORD_FINDER = re2.compile(r"(?<=\b[a-zA-Z]{1,2})\n")
+NEWLINE_IN_MIDDLE_OF_WORD_FINDER = re2.compile(r"(?<=\w)\n(?=\w)")
 
 # https://regex101.com/r/VMfP98/3/substitution
 NEWLINE_FOLLOWED_BY_PERIOD_FINDER = re.compile(r"\n(?=\.(?=\s))")

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -67,8 +67,8 @@ HTML_TAGS_FINDER = re.compile(
 
 # -- Regex ported from pysbd --
 
-# https://regex101.com/r/0dTHBO/3/substitution
-NEWLINE_IN_MIDDLE_OF_WORD_FINDER = re2.compile(r"(?<=\w)\n(?=\w)")
+# https://regex101.com/r/0dTHBO/4/substitution
+NEWLINE_BETWEEN_WORD_CHARS = re2.compile(r"(?<=\w)\n(?=\w)")
 
 # https://regex101.com/r/VMfP98/3/substitution
 NEWLINE_FOLLOWED_BY_PERIOD_FINDER = re.compile(r"\n(?=\.(?=\s))")
@@ -82,7 +82,7 @@ CONSECUTIVE_FORWARD_SLASH_FINDER = re.compile(r"\/{3}")
 
 def _clean_ocr_text(text: str) -> str:
     cleaned_text = text.replace("''", '"')
-    cleaned_text = NEWLINE_IN_MIDDLE_OF_WORD_FINDER.sub("", cleaned_text)
+    cleaned_text = NEWLINE_BETWEEN_WORD_CHARS.sub("", cleaned_text)
     cleaned_text = NEWLINE_FOLLOWED_BY_PERIOD_FINDER.sub("", cleaned_text)
     cleaned_text = HEADING_OR_LIST_FINDER.sub(" ", cleaned_text)
     cleaned_text = NO_SPACE_BETWEEN_SENTENCES_FINDER.sub(" ", cleaned_text)


### PR DESCRIPTION
Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR text cleanup: new newline-handling removes line breaks that occur between adjacent word characters, yielding cleaner, more continuous text output from OCR processing and reducing spurious breaks in words and phrases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->