### PR TITLE
Make lang required, auto is now opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.5.0] - Unreleased
 
 ### Added
-- **Automatic language detection** ([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)): `BoundaryDetector(lang="auto")` detects language from text on first paragraph via py3langid. Logs warning on confidence < 0.8.
+- **Automatic language detection** ([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)): Pass `lang="auto"` to detect language via py3langid. Logs when confidence < 0.8.
 - **`classify_language` utility** ([#86](https://github.com/speedyk-005/yasbd-lib/pull/86)): Wraps py3langid with softmax normalization and preference for supported languages.
 - **Amharic (am) language support** ([#91](https://github.com/speedyk-005/yasbd-lib/pull/91)).
 

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ And multilingual quirks a naive splitter never saw coming.
 
 Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 
-**Pass 1** — Naive boundary finder. Finds every position that could plausibly end a sentence: periods, question marks, exclamation points — anything followed by whitespace, uppercase, or a newline. Deliberately over-inclusive. Better to catch a false positive than miss a real boundary.
+**Pass 1** - Naive boundary finder. Finds every position that could plausibly end a sentence: periods, question marks, exclamation points - anything followed by whitespace, uppercase, or a newline. Deliberately over-inclusive. Better to catch a false positive than miss a real boundary.
 
-**Pass 2** — Cross-references 9+ mid-sentence patterns to surgically excise false positives:
+**Pass 2** - Cross-references 9+ mid-sentence patterns to surgically excise false positives:
 
 - Newline inside sentence
 - Title/initialism protection
@@ -182,11 +182,12 @@ from yasbd.boundary_detector import BoundaryDetector
 # Or from yasbd import BoundaryDetector
 
 # Basic setup
-detector = BoundaryDetector()
+detector = BoundaryDetector(lang="en")
 
 # With all options (so far.)
 detector = BoundaryDetector(
-	# ISO 639 code (e.g., en, fr, es, ...). Defaults to "auto".
+	# ISO 639 code (e.g., en, fr, es, ...). Required.
+	# Use "auto" for automatic detection.
 	# https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
     lang="fr",
 
@@ -210,8 +211,8 @@ The rule module loads lazily on first access. Switching mid-stream reimports the
 > [!TIP]
 > **Auto-detect**
 >
-> Keep lang="auto" if you want the system to figure out the language for you.
-> I wouldn’t lean on it too hard tho — it’s a bit slower, and short phrases can throw it off sometimes.
+> Pass `lang="auto"` if you want the system to figure out the language for you.
+> I wouldn't lean on it too hard tho — it's a bit slower, and short phrases can throw it off sometimes.
 
 ### Core Methods
 The two primary APIs are detect() and segment().
@@ -268,7 +269,7 @@ print(res)
 ```
 
 > [!TIP]
-> **ParagraphStream** — yasbd uses [`ParagraphStream`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.utils.paragraph_stream.ParagraphStream) internally to split text into paragraph blocks. You can import it directly if you need paragraph-level processing in your own code:
+> **ParagraphStream** - yasbd uses [`ParagraphStream`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.utils.paragraph_stream.ParagraphStream) internally to split text into paragraph blocks. You can import it directly if you need paragraph-level processing in your own code:
 > ```python
 > from yasbd.utils.paragraph_stream import ParagraphStream  # or yasbd.paragraph_stream
 >
@@ -330,7 +331,7 @@ cleaner = StreamCleaner(
 cleaner = StreamCleaner(
     text,
     extra_steps=[
-        lambda t: t.replace("™", ""),
+        lambda t: t.replace("TM", ""),
         lambda t: t.upper(),
     ],
 )
@@ -373,7 +374,7 @@ yasbd detect "Hello world. How are you?"
 yasbd segment --file document.txt
 yasbd segment --file input.txt --destination output.txt  # JSONL output
 
-# Pipe support — auto-detects, skips [N] enumeration
+# Pipe support - auto-detects, skips [N] enumeration
 echo "Hello. World." | yasbd segment | cat
 # Hello.
 # World.
@@ -422,9 +423,9 @@ Migrating from pysbd? Swap the import and keep your pipeline:
 from yasbd.utils.pysbd_adapter import Segmenter  # or yasbd.pysbd_adapter
 
 seg = Segmenter(language="ja")
-res = seg.segment('田中さんは「準備は完了しました」そう言って部屋を出た。Ｕ．Ｓ．Ａ．の経済政策は非常に複雑です。')
+res = seg.segment('田中さんは「準備は完了しました」そう言って部屋を出た。U.S.A.の経済政策は非常に複雑です。')
 print(res)
-# ['田中さんは「準備は完了しました」そう言って部屋を出た。', 'Ｕ．Ｓ．Ａ．の経済政策は非常に複雑です。']
+# ['田中さんは「準備は完了しました」そう言って部屋を出た。', 'U.S.A.の経済政策は非常に複雑です。']
 ```
 
 Same API surface. Same [`Segmenter`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.utils.pysbd_adapter.Segmenter) class. Same [`segment()`](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbd.utils.pysbd_adapter.Segmenter.segment) method signature.
@@ -462,6 +463,6 @@ Interested in contributing? See the [**Contributing Guide**](https://github.com/
 
 ## 📜 Last note
 
-**yasbd** is maintained by [speedyk-005](https://github.com/speedyk-005). Licensed under [Mozilla Public License 2.0](https://github.com/speedyk-005/yasbd-lib/blob/main/LICENSE) — you can use it freely in commercial and private work.
+**yasbd** is maintained by [speedyk-005](https://github.com/speedyk-005). Licensed under [Mozilla Public License 2.0](https://github.com/speedyk-005/yasbd-lib/blob/main/LICENSE) - you can use it freely in commercial and private work.
 
 Star us on GitHub if you dig it. Tell your NLP pipeline we said hi. 🚀

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -41,9 +41,9 @@ class BoundaryDetector:
         self._rule_cache: OrderedDict[str, object] = OrderedDict()
 
         if not lang:
-              raise InvalidInputError(
-                  f"'lang' is required.\nOptions: {', '.join(get_supported_langs())}"
-               )
+            raise InvalidInputError(
+                f"'lang' is required.\nOptions: {', '.join(get_supported_langs())}"
+            )
         self.lang = lang.lower()
 
         if lang == "auto":

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -46,7 +46,7 @@ class BoundaryDetector:
             )
         self.lang = lang.lower()
 
-        if lang == "auto":
+        if self.lang == "auto":
             classify_language("MOCK")  # prime py3langid model
 
         log_info(

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -1,10 +1,10 @@
-import warnings
 from collections import OrderedDict
 from collections.abc import Generator, Iterable
 from io import TextIOBase
 from itertools import chain, tee
 
-from yasbd.rules import load_rule
+from yasbd.exceptions import InvalidInputError
+from yasbd.rules import get_supported_langs, load_rule
 from yasbd.utils.cleaner_stub import StreamCleanerStub
 from yasbd.utils.input_validator import validate_input
 from yasbd.utils.language_classifier import classify_language
@@ -20,7 +20,7 @@ class BoundaryDetector:
     @validate_input
     def __init__(
         self,
-        lang: str = "auto",
+        lang: str | None = None,
         *,
         preserve_quote_and_paren: bool = True,
         verbose: bool = False,
@@ -29,7 +29,9 @@ class BoundaryDetector:
 
         Args:
             lang: Two chars ISO language code (e.g., 'en', 'fr', ...).
-                Defaults to 'auto'
+                Use 'auto' for automatic language detection via py3langid.
+                Explicit is faster and more reliable; use auto if you don't
+                mind a slight decrease in both.
             preserve_quote_and_paren: Do not split on terminators inside
                 quoted or parenthesised text.
             verbose: Enable verbose logging.
@@ -37,15 +39,16 @@ class BoundaryDetector:
         self.preserve_quote_and_paren = preserve_quote_and_paren
         self.verbose = verbose
         self._rule_cache: OrderedDict[str, object] = OrderedDict()
-        if lang == "auto":
-            warnings.warn(
-                "Auto-detect works, but explicit is faster and more reliable, "
-                "especially with short texts. "
-                "Consider setting `lang` explicit  if you know it.",
-                UserWarning,
-                stacklevel=5,
-            )
+
+        if not lang:
+              raise InvalidInputError(
+                  f"'lang' is required.\nOptions: {', '.join(get_supported_langs())}"
+               )
         self.lang = lang.lower()
+
+        if lang == "auto":
+            classify_language("MOCK")  # prime py3langid model
+
         log_info(
             self.verbose,
             "Initialized with lang={!r}, preserve_quote_and_paren={}, verbose={}",

--- a/src/yasbd/rules/__init__.py
+++ b/src/yasbd/rules/__init__.py
@@ -11,13 +11,13 @@ from yasbd.rules.base import Rules
 def get_supported_langs() -> list[str]:
     """Discover and cache supported language codes from the rules directory."""
     rules_dir = Path(__file__).parent
-    langs: list[str] = []
+    langs = []
     for f in rules_dir.iterdir():
         if f.stem in ("_template", "base", "__init__"):
             continue
         if f.suffix == ".py":
             langs.append(f.stem)
-    return sorted(langs)
+    return ["auto"] + sorted(langs)
 
 
 def load_rule(lang: str) -> Rules:

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -5,7 +5,12 @@ import string
 import pytest
 
 from tests import ALL_TEST_DATA
-from yasbd import BoundaryDetector, ParagraphEOF, UnsupportedLanguageError
+from yasbd import (
+    BoundaryDetector,
+    InvalidInputError,
+    ParagraphEOF,
+    UnsupportedLanguageError,
+)
 
 
 @pytest.fixture(scope="module")
@@ -27,10 +32,18 @@ def test_segment_empty_input(input_text, en_detector):
     assert list(en_detector.segment(input_text)) == []
 
 
-def test_unsupported_language():
-    """test that unknown language codes raise UnsupportedLanguageError."""
-    with pytest.raises(UnsupportedLanguageError, match="Unsupported language"):
-        BoundaryDetector(lang="xx")
+@pytest.mark.parametrize(
+    "lang,exc,msg",
+    [
+        (None, InvalidInputError, "'lang' is required"),
+        ("", InvalidInputError, "'lang' is required"),
+        ("xx", UnsupportedLanguageError, "Unsupported language"),
+    ],
+)
+def test_invalid_lang(lang, exc, msg):
+    """test that invalid/missing language codes raise the expected error."""
+    with pytest.raises(exc, match=msg):
+        BoundaryDetector(lang=lang)
 
 
 def test_segment_different_input(en_detector):


### PR DESCRIPTION
## Summary

Makes `lang` a required parameter and moves auto-detection behind an explicit `lang="auto"` opt-in.

### Why auto is not the default

1. **Cold-start cost:** ~155ms penalty on first segment to load py3langid model. With warmup at init, still 30× slower than explicit (31ms vs 1ms).
2. **Predictability:** auto-detection is non-deterministic; confidence fluctuates on short text. Explicit `lang` gives reproducible results.

Auto is still a great power-user feature — just opt-in when you actually need mixed-language support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Language must be specified; initializing without a language now raises an error listing supported languages (including "auto").

* **Documentation**
  * README and examples updated to show explicit language handling, using lang="auto" for detection, and logging when confidence < 0.8; minor wording/formatting tweaks.

* **Tests**
  * Expanded tests to cover invalid/empty/unsupported language cases with parametrized assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->