### PR TITLE
Add Dutch language support and update German date abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Korean (ko) language support** ([#113](https://github.com/speedyk-005/yasbd-lib/pull/113)).
 
+### Fixed
+- **German `DATE_ABBRVS`**: Removed "mai" — it's a full word, not an abbreviation.
+
 ---
 
 ## [0.7.0] - 2026-06-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **Korean (ko) language support** ([#113](https://github.com/speedyk-005/yasbd-lib/pull/113)).
+- **Dutch (nl) language support** ([#114](https://github.com/speedyk-005/yasbd-lib/pull/114)).
 
 ### Fixed
 - **German `DATE_ABBRVS`**: Removed "mai" — it's a full word, not an abbreviation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Korean (ko) language support** ([#113](https://github.com/speedyk-005/yasbd-lib/pull/113)).
 - **Dutch (nl) language support** ([#114](https://github.com/speedyk-005/yasbd-lib/pull/114)).
+- **German military rank titles**: Added to `TITLE_ABBRVS` ([#114](https://github.com/speedyk-005/yasbd-lib/pull/114)).
 
 ### Fixed
 - **German `DATE_ABBRVS`**: Removed "mai" — it's a full word, not an abbreviation.
+- **ORDINAL regex (de, nl)**: Changed `\d+` to `\d{1,3}` to avoid false sentence breaks after 3+ digit numbers ([#114](https://github.com/speedyk-005/yasbd-lib/pull/114)).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 
 ## 🌐 Supported Languages
 
-17 languages supported today. Target is 22+.
+18 languages supported today. Target is 22+.
 
 <details>
 <summary>Click to see all supported languages</summary>
@@ -109,6 +109,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 | 🇮🇹 | it   | Italian |
 | 🇯🇵 | ja   | Japanese |
 | 🇰🇷 | ko   | Korean |
+| 🇳🇱 | nl   | Dutch |
 | 🇲🇲 | my   | Burmese |
 | 🇵🇹 | pt   | Portuguese |
 | 🇷🇺 | ru   | Russian |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,7 +10,7 @@ So you want to know how yasbd stacks up against the competition? Fair enough. He
 | nupunkt | Zero deps, legal-text optimized. Claims 91.1% precision at 10M chars/sec. ~12 langs. | [GitHub](https://github.com/alea-institute/nupunkt) / [pypi](https://pypi.org/project/nupunkt/) |
 | blingfire | Microsoft C++ FSM + Python bindings. Language agnostic. | [GitHub](https://github.com/microsoft/BlingFire) / [pypi](https://pypi.org/project/blingfire/) |
 | sentence-splitter | Heuristic algorithm from Europarl (Koehn/Schroeder). Archived 2025. | [GitHub](https://github.com/mediacloud/sentence-splitter) / [pypi](https://pypi.org/project/sentence-splitter/) |
-| yasbd | Pure Python, 14 langs and growing. Pointer-based SBD with pysbd adapter. | *(this repo)* |
+| yasbd | Pure Python, 18 langs and growing. Pointer-based SBD with pysbd adapter. | *(this repo)* |
 
 Not every library supports every language. We picked multiple languages that stress different weaknesses.
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -34,7 +34,7 @@ class Rules:
 
         # Military (NATO/International Standardized Ranks)
         "adm", "brig", "capt", "cmdr", "comdr", "commr", "col", "cpl", "gen", "lt",
-        "maj", "sgt", "pvt",
+        "maj", "sgt", "serg", "pvt", "kapt",
 
         # Political/Administrative (Common in Western bureaucracy)
         "gov", "rep", "sen", "pres", "sec", "min", "mgr", "asst", "det", "surg",

--- a/src/yasbd/rules/de.py
+++ b/src/yasbd/rules/de.py
@@ -46,7 +46,7 @@ class DeRules(Rules):
 
     DATE_ABBRVS = Rules.DATE_ABBRVS | {
         # Months
-        "mär", "mai", "okt", "dez",
+        "mär", "okt", "dez",
 
         # Days
         "mo", "di", "mi", "do", "fr", "sa", "so",

--- a/src/yasbd/rules/de.py
+++ b/src/yasbd/rules/de.py
@@ -10,6 +10,10 @@ class DeRules(Rules):
     TITLE_ABBRVS = Rules.TITLE_ABBRVS | {
         "dr.h.c", "di", "dipl", "dipl.-Ing", "mag", "ba", "ma", "bsc", "msc",
         "h", "hr", "hnr", "hll", "frl", "min", "pfr", "ass", "​projektass",
+
+        # Military Ranks
+        "gen", "lt", "maj", "oberstlt", "kpt", "kptlt", "fkpt", "kkpt",
+        "stabsgefr", "uoff", "stabsfw",
     }
 
     DOTTED_GEOPOL_ABBRVS = Rules.DOTTED_GEOPOL_ABBRVS | {
@@ -110,7 +114,7 @@ class DeRules(Rules):
 
             # Ordinal numbers
             # https://learngerman.dw.com/en/ordinal-numbers/l-57731450/gr-60885529
-            re.compile(r"\s\d+\."),
+            re.compile(r"\s\d{1,3}\."),
 
             # Multi-part abbreviations with spaces (like "d. h.", "z. B.", "i. d. R.")
             re.compile(r"\b[a-zA-Z]\.(?!\s+\w{2,})"),

--- a/src/yasbd/rules/nl.py
+++ b/src/yasbd/rules/nl.py
@@ -77,7 +77,7 @@ class NlRules(Rules):
         "Wiens", "Wier",
 
         # Adverbs and Connectors
-        "Echter", "Bovendien", "Desandanks", "Daarom", "Daardoor", "Dus",
+        "Echter", "Bovendien", "Desondanks", "Daarom", "Daardoor", "Dus",
         "Desalniettemin", "Niettemin", "Intussen", "Inmiddels", "Tevens",
         "Verder", "Tenslotte", "Uiteindelijk", "Vervolgens", "Voorlopig",
         "Overigens", "Trouwens", "Anderzijds", "Enerzijds", "Immers",

--- a/src/yasbd/rules/nl.py
+++ b/src/yasbd/rules/nl.py
@@ -1,10 +1,9 @@
-import re
-
-from yasbd.rules.base import Rules, _build_abbr_pattern
+from yasbd.rules.base import Rules
+from yasbd.rules.de import DeRules
 
 
 # fmt: off
-class NlRules(Rules):
+class NlRules(DeRules):
 
 
     TITLE_ABBRVS = Rules.TITLE_ABBRVS | {
@@ -108,40 +107,3 @@ class NlRules(Rules):
      }
 
     # fmt: on
-    @classmethod
-    def _compile_regex_dynamically(cls):
-        """Override base regex compilation to handle ellipsis, ord num and time"""
-        super()._compile_regex_dynamically()
-
-        cls.MID_SENTENCE_FINDER_LST.extend([
-            # Spaced three-dot ellipsis mid-thought (e.g., ". . . she didn't")
-            # Consecutive dots "..." or "...." still create sentence boundaries.
-            re.compile(r"(?<!\.)\.(?:\s\.){2}"),
-
-            # Ordinal numbers
-            # https://learngerman.dw.com/en/ordinal-numbers/l-57731450/gr-60885529
-            re.compile(r"\s\d{1,3}\."),
-
-            # Number/Time abbreviations followed by a date token (e.g., 9 a.m. Monday)
-            re.compile(rf"""
-                (?:\d\.|(?:(?<=\d)|\b)(?i:[ap]\.m\.))
-                (?=
-                    \s+(?i:{_build_abbr_pattern(cls.DATE_ABBRVS | cls.DATE_WORDS)})
-                    (?:\.|\s|$)
-                )
-            """, re.X),
-        ])
-
-        # Street abbrv followed by a common starters
-        cls.ENDING_STREET_ABBRVS_FINDER = re.compile(rf"""
-            (?:\b(?i:{_build_abbr_pattern(cls.STREET_ABBRVS)})\.)
-            (?=\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)
-           """, re.X
-        )
-
-    def _post_process_boundaries(
-        self, main_boundaries: set[int], text: str
-    ) -> None:
-        main_boundaries.update(
-            m.end() for m in self.ENDING_STREET_ABBRVS_FINDER.finditer(text)
-        )

--- a/src/yasbd/rules/nl.py
+++ b/src/yasbd/rules/nl.py
@@ -120,7 +120,7 @@ class NlRules(Rules):
 
             # Ordinal numbers
             # https://learngerman.dw.com/en/ordinal-numbers/l-57731450/gr-60885529
-            re.compile(r"\s\d+\."),
+            re.compile(r"\s\d{1,3}\."),
 
             # Number/Time abbreviations followed by a date token (e.g., 9 a.m. Monday)
             re.compile(rf"""

--- a/src/yasbd/rules/nl.py
+++ b/src/yasbd/rules/nl.py
@@ -1,0 +1,147 @@
+import re
+
+from yasbd.rules.base import Rules, _build_abbr_pattern
+
+
+# fmt: off
+class NlRules(Rules):
+
+
+    TITLE_ABBRVS = Rules.TITLE_ABBRVS | {
+        # Academic and Professional Titles
+        "dr", "drs", "prof", "mr", "ir", "ing", "lic", "bc",
+
+        # Bachelor / Master Degrees
+        "ba", "ma", "bsc", "msc",
+
+        # Social Honorifics and Clergy
+        "dhr", "mevr", "mw", "ds",
+
+        # Military Ranks
+        "gen", "lt-gen", "maj-gen", "briga", "kol", "lt-kol", "maj",
+        "kapt", "lt", "elnt", "tlnt", "serg", "korp",
+    }
+
+    DOTTED_GEOPOL_ABBRVS = Rules.DOTTED_GEOPOL_ABBRVS | {
+        "A.U", "E.G", "V.S", "N.V", "B.V", "V.K",
+    }
+
+    REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
+        # Bibliographical, Page, and Document References
+        "art", "afb", "hfdst", "blz", "nr",  "par", "reg",
+        "bijl", "ca", "cf", "ed", "vert", "id",
+
+        # Legal, Corporate, and Formal Citation Markers
+        "b.w", "stb", "gem", "coll", "hr", "c.q", "ov", "vp",
+    }
+
+    SECTION_MARKERS = Rules.SECTION_MARKERS | {
+        "Afdeling", "Artikel", "Lid", "Paragraaf", "Bijlage",
+        "Hoofdstuk", "Deel", "Inleiding", "Voorwoord",
+        "Samenvatting", "Conclusie", "Register",
+    }
+
+    # Multi-part lowercase spaced/dotted abbreviations like "e. g." or "i. e."
+    # are caught dynamically later by the cls.MID_SENTENCE_FINDER_LST regex rule.
+    INLINE_ONLY_ABBRVS = Rules.INLINE_ONLY_ABBRVS | {
+       # Bridge / Logical connectors
+       "ebd", "dwz", "bijv", "evtl", "incl", "excl", "zgn", "ca",
+
+        # Business/Commercial
+        "tel", "fax", "attn",
+    }
+
+    DATE_ABBRVS = Rules.DATE_ABBRVS | {
+        # Months
+        "jan", "feb", "mrt", "apr", "jun", "jul",
+        "aug", "sep", "okt", "nov", "dec",
+
+        # Days
+        "ma", "di", "wo", "do", "vr", "za", "zo",
+    }
+
+    NAMES_WITH_EXCLAMATION = Rules.NAMES_WITH_EXCLAMATION | {
+        "Nu", "Doe mee", "Tikkie", "Vergeet je tandenborstel niet"
+    }
+
+    COMMON_SENT_STARTERS = {
+        # Articles
+        "De", "Het", "Een",
+
+        # Pronouns
+        "Ik", "We", "Wij", "Je", "Jij", "U", "Jullie", "Hij", "Zij", "Ze",
+        "Men", "Die", "Deze", "Dit", "Dat", "Gene", "Er",
+
+        # Question words
+        "Wie", "Wat", "Waar", "Wanneer", "Waarom", "Hoe", "Welke", "Welk",
+        "Wiens", "Wier",
+
+        # Adverbs and Connectors
+        "Echter", "Bovendien", "Desandanks", "Daarom", "Daardoor", "Dus",
+        "Desalniettemin", "Niettemin", "Intussen", "Inmiddels", "Tevens",
+        "Verder", "Tenslotte", "Uiteindelijk", "Vervolgens", "Voorlopig",
+        "Overigens", "Trouwens", "Anderzijds", "Enerzijds", "Immers",
+        "Namelijk", "Kortom", "Aldus", "Zodoende", "Bijgevolg", "Daarnaast",
+        "Daarentegen", "Toch", "Hoewel", "Ondertussen",
+
+        # Time / Sequence Anchors
+        "Later", "Vroeger", "Daarna", "Vandaag", "Gisteren", "Morgen",
+        "Eerst", "Toen", "Nu", "Soms", "Vaak", "Altijd", "Nooit",
+
+        # Common Noun Starters
+        "Mensen", "Miljoen",
+    }
+
+    STREET_ABBRVS = {
+        "str", "st", "ln", "pl", "rd", "wgh", "plts", "hbf", "geb"
+    }
+    INLINE_ONLY_ABBRVS |= STREET_ABBRVS
+
+    DATE_WORDS = {
+        # Months
+        "januari", "februari", "maart", "april", "mei", "juni",
+        "juli", "augustus", "september", "oktober", "november", "december",
+
+        # Days
+        "maandag", "dinsdag", "woensdag", "donderdag", "vrijdag",
+        "zaterdag", "zondag",
+     }
+
+    # fmt: on
+    @classmethod
+    def _compile_regex_dynamically(cls):
+        """Override base regex compilation to handle ellipsis, ord num and time"""
+        super()._compile_regex_dynamically()
+
+        cls.MID_SENTENCE_FINDER_LST.extend([
+            # Spaced three-dot ellipsis mid-thought (e.g., ". . . she didn't")
+            # Consecutive dots "..." or "...." still create sentence boundaries.
+            re.compile(r"(?<!\.)\.(?:\s\.){2}"),
+
+            # Ordinal numbers
+            # https://learngerman.dw.com/en/ordinal-numbers/l-57731450/gr-60885529
+            re.compile(r"\s\d+\."),
+
+            # Number/Time abbreviations followed by a date token (e.g., 9 a.m. Monday)
+            re.compile(rf"""
+                (?:\d\.|(?:(?<=\d)|\b)(?i:[ap]\.m\.))
+                (?=
+                    \s+(?i:{_build_abbr_pattern(cls.DATE_ABBRVS | cls.DATE_WORDS)})
+                    (?:\.|\s|$)
+                )
+            """, re.X),
+        ])
+
+        # Street abbrv followed by a common starters
+        cls.ENDING_STREET_ABBRVS_FINDER = re.compile(rf"""
+            (?:\b(?i:{_build_abbr_pattern(cls.STREET_ABBRVS)})\.)
+            (?=\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)
+           """, re.X
+        )
+
+    def _post_process_boundaries(
+        self, main_boundaries: set[int], text: str
+    ) -> None:
+        main_boundaries.update(
+            m.end() for m in self.ENDING_STREET_ABBRVS_FINDER.finditer(text)
+        )

--- a/tests/test_data/dutch.py
+++ b/tests/test_data/dutch.py
@@ -1,0 +1,46 @@
+ISO_CODE = "nl"
+TEST_DATA = [
+    # Basic punctuation
+    "Hallo wereld!| Hoe gaat het met je?| Met mij gaat het goed.",
+    "Wat is je naam?| Mijn naam is Jonas.",
+    "Daar is het!| Ik heb het eindelijk gevonden.",
+    "Heb je nummer 2 verwijderd?| Maak het alsjeblieft ongedaan.",
+
+    # Abbreviations
+    "Mijn naam is Jonas E. Schmidt.",
+    "Blader alstublieft naar pag. 55.",
+    "Ik kan de Mt. Fuji vanaf hier zien liggen.",
+    "St. Michael ligt in de 5e straat vlakbij het stoplicht.",
+    "Ik heb 3 dingen nodig, o.a. een hoed, een jas en een tas.",
+    "Het rapport werd in dec. gepubliceerd.| Het werd goedgekeurd door prof. Schmidt und mr. Jones.",
+    "De temperatuur bereikte 37,5 °C om 6 uur op di. 4 feb.",
+    "Zie afb. 2 in deel 3, hfdst. 4, blz. 18-22.",
+    "Het bewijs is weergegeven in art. 7 en bijl. IV.",
+    "We zien elkaar op vr. 14 feb.",
+    "U vindt het onder nr. 1026.253.553.| Daar ligt de schat.",
+    "We kiezen eerst optie A.| Daarna bespreken we de details.",
+
+    # Structural headings
+    "Hoofdstuk 1. Het begin.| Het was donker en stil in de kamer.| Niets bewoog.",
+    "Afdeling 3.1. Reikwijdte van de werkzaamheden.| Het project omvat meerdere talen.",
+    "De resultaten waren niet eenduidig.| Hoofdstuk 3. Discussie volgt onmiddellijk.| Het team heeft het model herzien.",
+
+    # Parentheses and quotes
+    "Hij geeft les in de natuurwetenschappen (hij werkte voorheen 5 jaar als ingenieur) aan de lokale universiteit.",
+    "(Zie afb. 4. Dit schetst de geheugenlay-out.)| De engine voert de volgende stap uit.",
+    'Ze draaide zich naar hem toe: „Dit is geweldig.“| Ze hield hem het boek voor.',
+    '„Is dit oké?“, vroeg ze.',
+    "Volgens zijn uitgever kocht Schmidt het bedrijf in 1985 [of 1984?], maar was pas vanaf 1990 actief.",
+    'Toen stopte hij.| „Wacht“, zei hij.',
+    "De brief sloot af met een simpele waarschuwing: ‘Volg me niet.’| Toen ging ze.",
+    'Er zei: „Eerste zin. Tweede zin.“| Toen was hij klaar.',
+
+    # Ellipsis
+    "Het project (Sinta) was bijna afgerond... of dat dachten we tenminste.",
+    '„Hoe hebben we dit over het hoofd kunnen zien!...“| Mark schreeuwde en sloeg met zijn hand op tafel.',
+    "We hebben een geheugenlek gevonden in de C#-wrapper....| Het was subtiel.",
+
+    # Mixed language
+    "De vergadering is om 14 uur.| 请别迟到。",
+    "那个会议在下午两点。|Please don't be late!"
+]


### PR DESCRIPTION
Part #20

**Summary**

Add Dutch (nl) language support with 32 test cases, inheriting shared patterns from `DeRules` to avoid duplication. Fixes a few German rules found along the way (mai in DATE_ABBRVS, ordinal regex range).

**What Changed**

- Dutch sentence segmentation with full abbreviation sets, street markers, date parsing, and sentence starters
- Inherits `_compile_regex_dynamically` and `_post_process_boundaries` from `DeRules` instead of copying (~97% reduction in duplicate code in nl.py)
- Ordinal regex tightened from `\d+` to `\d{1,3}` to reduce false boundary suppression
- "mai" removed from German `DATE_ABBRVS` — it's the full word, not an abbreviation

**Testing**

32 test cases covering abbreviations, ordinals, titles, quotes, ellipsis, mixed languages. All 40 existing tests pass, 537 subtests.