### PR TITLE
Extract CJKV full-width abbreviation pattern into shared mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dutch (nl) language support** ([#114](https://github.com/speedyk-005/yasbd-lib/pull/114)).
 - **German military rank titles**: Added to `TITLE_ABBRVS` ([#114](https://github.com/speedyk-005/yasbd-lib/pull/114)).
 
+### Changed
+
+- **CJKV mixin** ([#115](https://github.com/speedyk-005/yasbd-lib/pull/115)): Shared full-width abbreviation pattern extracted from ``zh``, ``ja``, ``ko`` into ``base.py``.
+
 ### Fixed
 - **German `DATE_ABBRVS`**: Removed "mai" — it's a full word, not an abbreviation.
 - **ORDINAL regex (de, nl)**: Changed `\d+` to `\d{1,3}` to avoid false sentence breaks after 3+ digit numbers ([#114](https://github.com/speedyk-005/yasbd-lib/pull/114)).
 - **Language tag normalization helper** ([#112](https://github.com/speedyk-005/yasbd-lib/pull/112)).
-
-### Fixed
-- **German `DATE_ABBRVS`**: Removed "mai" — it's a full word, not an abbreviation.
 
 ---
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -17,6 +17,20 @@ def _build_abbr_pattern(options: set[str]) -> str:
     return trie.add(*options).pattern()
 
 
+class CJKV:
+    """Mixin for CJKV languages sharing full-width geopolitical abbreviation patterns."""
+
+    @classmethod
+    def _compile_regex_dynamically(cls):
+        """Override base regex compilation to fix geopolitical split when used as adj"""
+        super()._compile_regex_dynamically()
+
+        cls.MID_SENTENCE_FINDER_LST.append(
+            # Full-width geopolitical abbreviations
+            re.compile(r"(?:[\uFF21-\uFF3A\uFF41-\uFF5A\uFF10-\uFF19]．){1,5}")
+        )
+
+
 # fmt: off
 class Rules:
     TERMINATORS = {

--- a/src/yasbd/rules/ja.py
+++ b/src/yasbd/rules/ja.py
@@ -1,10 +1,8 @@
-import re
-
-from yasbd.rules.base import Rules
+from yasbd.rules.base import CJKV, Rules
 
 
 # fmt: off
-class JaRules(Rules):
+class JaRules(CJKV, Rules):
 
 
     NAMES_WITH_EXCLAMATION = Rules.NAMES_WITH_EXCLAMATION | {
@@ -35,14 +33,4 @@ class JaRules(Rules):
         # embedded quotation structures
         "ように", "らしいと", "そうだと",
     }
-
-    # fmt: on
-    @classmethod
-    def _compile_regex_dynamically(cls):
-        """Override base regex compilation to fix geopolitical split when used as adj"""
-        super()._compile_regex_dynamically()
-
-        cls.MID_SENTENCE_FINDER_LST.append(
-            # Full-width geopolitical abbreviations
-            re.compile(r"(?:[\uFF21-\uFF3A\uFF41-\uFF5A\uFF10-\uFF19]．){1,5}")
-        )
+# fmt: on

--- a/src/yasbd/rules/ko.py
+++ b/src/yasbd/rules/ko.py
@@ -1,10 +1,8 @@
-import re
-
-from yasbd.rules.base import Rules
+from yasbd.rules.base import CJKV, Rules
 
 
 # fmt: off
-class KoRules(Rules):
+class KoRules(CJKV, Rules):
 
 
     NAMES_WITH_EXCLAMATION = Rules.NAMES_WITH_EXCLAMATION | {
@@ -37,14 +35,4 @@ class KoRules(Rules):
         # Clausal extensions
         "하며", "하면서", "라고는", "고는",
     }
-
-    # fmt: on
-    @classmethod
-    def _compile_regex_dynamically(cls):
-        """Override base regex compilation to fix geopolitical split when used as adj"""
-        super()._compile_regex_dynamically()
-
-        cls.MID_SENTENCE_FINDER_LST.append(
-            # Full-width geopolitical abbreviations
-            re.compile(r"(?:[\uFF21-\uFF3A\uFF41-\uFF5A\uFF10-\uFF19]．){1,5}")
-        )
+# fmt: on

--- a/src/yasbd/rules/zh.py
+++ b/src/yasbd/rules/zh.py
@@ -1,10 +1,8 @@
-import re
-
-from yasbd.rules.base import Rules
+from yasbd.rules.base import CJKV, Rules
 
 
 # fmt: off
-class ZhRules(Rules):
+class ZhRules(CJKV, Rules):
 
 
     NAMES_WITH_EXCLAMATION = Rules.NAMES_WITH_EXCLAMATION | {
@@ -19,14 +17,4 @@ class ZhRules(Rules):
         "说", "道", "喊", "问", "答", "回答", "称", "指出",
         "表示", "认为", "坦言", "强调", "写道", "报道", "解释", "反驳"
     }
-
-    # fmt: on
-    @classmethod
-    def _compile_regex_dynamically(cls):
-        """Override base regex compilation to fix geopolitical split when used as adj"""
-        super()._compile_regex_dynamically()
-
-        cls.MID_SENTENCE_FINDER_LST.append(
-            # Full-width geopolitical abbreviations
-            re.compile(r"(?:[\uFF21-\uFF3A\uFF41-\uFF5A\uFF10-\uFF19]．){1,5}")
-        )
+# fmt: on


### PR DESCRIPTION
### Summary

Extract the duplicated full-width geopolitical abbreviation pattern from zh, ja, and ko into a shared `CJKV` mixin. No behavioral change — reduces duplication and makes adding future CJKV languages a one-liner.

### What Changed

- zh, ja, ko now inherit from the `CJKV` mixin instead of each defining an identical `_compile_regex_dynamically` override
- The mixin sits in `base.py` alongside `Rules`, ready for other language groups (Germanic, Romance, etc.) to follow the same pattern

### Testing

- All 537 subtests pass across all languages, including the 4 Chinese full-width abbreviation cases that exercise this exact pattern
- Ruff clean