### PR TITLE
Split after coordinate direction abbreviations

### DIFF
--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -294,8 +294,11 @@ class Rules:
             # excluding geopolitical ones not followed by a common starters
             re2.compile(rf"""
                 (?:
-                    (?<=[.\s])
-                    \p{{Lu}}|\b\p{{Lo}}
+                    # Preserve single-letter initials, but let coordinate directions
+                    # after digits or degree signs terminate sentences.
+                    (?<![\d°]\s)(?<=[.\s])(?i:[nsew])|
+                    (?<=[.\s])(?! (?i:[nsew])\. )\p{{Lu}}|
+                    \b\p{{Lo}}
                 )\.
                 (?<!(?i:{cls.DOTTED_GEOPOL_ABBRVS_PATTERN}|p\.m|a\.m){cls.DOTS_PATTERN})
                 (?!\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -56,6 +56,19 @@ def test_segment_different_input(en_detector):
     assert result_stream == ["Hello world.", "How are you?", "I'm fine."]
 
 
+def test_segment_coordinate_direction_sentence_end(en_detector):
+    """test that coordinate direction abbreviations can terminate sentences."""
+    text = (
+        "Server A was located at 40.7128° N, 74.0060° W. "
+        "Server B was located at 34.0522° S, 118.2437° E."
+    )
+
+    assert list(en_detector.segment(text)) == [
+        "Server A was located at 40.7128° N, 74.0060° W.",
+        "Server B was located at 34.0522° S, 118.2437° E.",
+    ]
+
+
 @pytest.mark.parametrize("lang,test_data", ALL_TEST_DATA.items())
 def test_segment_multiple_langs(subtests, lang, test_data):
     """test that each language's test data passes."""


### PR DESCRIPTION
### Objective
Fix sentence splitting after coordinate direction abbreviations such as `N.`, `S.`, `E.`, and `W.` when they appear at the end of a geographic coordinate sentence.

### Changes
- Narrowed the single-letter initialism rule so coordinate directions following a digit or degree sign are allowed to terminate a sentence.
- Added a regression test covering `N./S./E./W.` coordinate directions while preserving existing single-letter initial behavior.

### Verification
- `uv run pytest tests/test_boundary_detector.py -q` — passed: 39 passed, 727 subtests passed
- `uv run pytest -q` — passed after installing optional `langcodes`: 65 passed, 2 skipped, 727 subtests passed
- `uv run ruff format --check .` — passed: 53 files already formatted
- `uv run ruff check .` — passed: All checks passed

### Related Issues
Fixes #133
