### PR TITLE
Treat cardinal directions (N., S., E., W.) as sentence terminators

### DIFF
--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -297,7 +297,7 @@ class Rules:
                     (?<=[.\s])
                     \p{{Lu}}|\b\p{{Lo}}
                 )\.
-                (?<!(?i:{cls.DOTTED_GEOPOL_ABBRVS_PATTERN}|p\.m|a\.m){cls.DOTS_PATTERN})
+                (?<!(?i:{cls.DOTTED_GEOPOL_ABBRVS_PATTERN}|p\.m|a\.m|N|S|E|W){cls.DOTS_PATTERN})
                 (?!\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)
                 """, re2.X
             ),

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -49,6 +49,10 @@ TEST_DATA = [
     "The store opens at 8 p.m. December.",
     "The meeting is at 2 p.m.| Martin called.",
     "The meeting is at 10 a.m.| Monday's agenda was postponed.",
+    # cardinal directions as sentence terminators (fix for #133)
+    "Server A was located at 40.7128° N, 74.0060° W.| Server B was located at 34.0522° N, 118.2437° W.",
+    "The wind blew from the N.| It was cold.",
+    "Head E. on Main St.| Turn N. at the light.",
 
     # structural headings (fix for #36)
     "Chapter 1. The Beginning.| It was dark and quiet in the room. | Nothing moved.",


### PR DESCRIPTION
## Summary

Fixes #133 — standalone compass direction abbreviations (`N.`, `S.`, `E.`, `W.`) were incorrectly treated as non-breaking initialisms, preventing sentence boundary detection after geographic coordinates.

## Before

```python
"Server A was located at 40.7128° N, 74.0060° W. Server B was located at 34.0522° N, 118.2437° W."
# → single sentence (W. treated as mid-sentence abbreviation)
```

## After

```python
"Server A was located at 40.7128° N, 74.0060° W.| Server B was located at 34.0522° N, 118.2437° W."
# → two sentences (W. correctly detected as sentence terminator)
```

## Root Cause

The Initialism/Acronyms rule in `MID_SENTENCE_FINDER_LST` (`base.py:300`) treated all single-letter abbreviations followed by a period as non-breaking, including standalone cardinal directions. The negative lookbehind only excluded geopolitical abbreviations, `p.m.`, and `a.m.`.

## Fix

Added `N`, `S`, `E`, `W` to the negative lookbehind alternation in the Initialism regex pattern. The `(?i:)` flag ensures case-insensitive matching. Multi-letter abbreviations (`A.B.`, `U.S.`, `a.m.`, `p.m.`) and geopolitical abbreviations (`E.U.`, `U.K.`) are unaffected.

## Files Changed

- `src/yasbd/rules/base.py` — add `|N|S|E|W` to the Initialism exclusion pattern (line 300)
- `tests/test_data/english.py` — add test cases for compass direction sentence boundaries

Closes #133