### PR TITLE
Post-cleanup for coordinate direction abbreviation fix from #134

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **CLI error handling**: catch `UnsupportedLanguageError` in `main()` for a clean error message instead of a Python traceback.
+- **Coordinate direction abbreviations** ([#134](https://github.com/speedyk-005/yasbd-lib/pull/134)): N., S., E., W. after digits/degree signs now terminate sentences (e.g., "40.7128° N."). Initials like "N. Scott Momaday" are preserved.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -559,6 +559,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@sanmaxdev](https://github.com/sanmaxdev)** | Language tag normalization helper |
 | **[@hongquan](https://github.com/hongquan)** | `py.typed` marker for PEP 561 compliance |
 | **[@terminalchai](https://github.com/terminalchai)** | Burmese and Thai reporting words fix |
+| **[@1cbyc](https://github.com/1cbyc)** | Coordinate direction abbreviation fix |
 
 Interested in contributing? See the [**Contributing Guide**](https://github.com/speedyk-005/yasbd-lib/blob/main/CONTRIBUTING.md) to get started!
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -291,16 +291,15 @@ class Rules:
             re.compile(r"\.(?=[ºª])"),
 
             # Initialism/Acronyms/Exclamations words (e.g., Yahoo!, A.B. Holding, Ave. Central)
-            # excluding geopolitical ones not followed by a common starters
+            # excluding coordinate directions or geopolitical ones not followed
+            # by a common starters
             re2.compile(rf"""
                 (?:
-                    # Preserve single-letter initials, but let coordinate directions
-                    # after digits or degree signs terminate sentences.
-                    (?<![\d°]\s)(?<=[.\s])(?i:[nsew])|
-                    (?<=[.\s])(?! (?i:[nsew])\. )\p{{Lu}}|
+                    (?<=\.)\p{{Lu}}|
+                    (?<=\s)\p{{Lu}}(?<![\d°]\s+[NSWE])|
                     \b\p{{Lo}}
                 )\.
-                (?<!(?i:{cls.DOTTED_GEOPOL_ABBRVS_PATTERN}|p\.m|a\.m){cls.DOTS_PATTERN})
+                (?<!(?i:{cls.DOTTED_GEOPOL_ABBRVS_PATTERN}|[pa]\.m){cls.DOTS_PATTERN})
                 (?!\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)
                 """, re2.X
             ),

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -56,19 +56,6 @@ def test_segment_different_input(en_detector):
     assert result_stream == ["Hello world.", "How are you?", "I'm fine."]
 
 
-def test_segment_coordinate_direction_sentence_end(en_detector):
-    """test that coordinate direction abbreviations can terminate sentences."""
-    text = (
-        "Server A was located at 40.7128° N, 74.0060° W. "
-        "Server B was located at 34.0522° S, 118.2437° E."
-    )
-
-    assert list(en_detector.segment(text)) == [
-        "Server A was located at 40.7128° N, 74.0060° W.",
-        "Server B was located at 34.0522° S, 118.2437° E.",
-    ]
-
-
 @pytest.mark.parametrize("lang,test_data", ALL_TEST_DATA.items())
 def test_segment_multiple_langs(subtests, lang, test_data):
     """test that each language's test data passes."""

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -115,6 +115,10 @@ TEST_DATA = [
     "Done. 🎉| Amazing result.",
     "The alternative is to put it before the full stop 👉.| So cool, right?",
 
+    # Coordinate directions (fix for #134)
+    "Server A at 40.7128° N, 74.0060° W.| Server B at 34.0522° S, 118.2437° E.",
+    "N. Scott Momaday is a writer.| He won the Pulitzer.",
+
     # Mixed language
     "我喜欢AI。|It is useful",
     "The meeting is at 2 p.m.| 请别迟到。",


### PR DESCRIPTION
Post-cleanup for coordinate direction abbreviation fix (#134)

## Summary

Cleanup and refactor following the coordinate direction sentence boundary fix from #134.

## Changes

- Simplified the regex pattern in `MID_SENTENCE_FINDER_LST` — replaced the explicit `N/S/E/W` branch with a cleaner `(?<=\.)\p{{Lu}}` fallback that excludes coordinates via `(?<![\d°]\s+[NSWE])`
- Moved the coordinate direction test from a dedicated unit test into `english.py` test data, adding an "N. Scott Momaday" case to ensure initials are preserved
- Updated CHANGELOG and added @1cbyc to contributors

## Testing

All 33 tests pass across all languages.
