### PR TITLE
Add Indonesian language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Indonesian (id) language support** ([#137](https://github.com/speedyk-005/yasbd-lib/pull/137)).
 - **Slovak (sk) language support** ([#129](https://github.com/speedyk-005/yasbd-lib/pull/129)).
 - **Vietnamese (vi) language support** ([#131](https://github.com/speedyk-005/yasbd-lib/pull/131)).
 - **Persian (fa) language support** ([#128](https://github.com/speedyk-005/yasbd-lib/pull/128)).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 
 ## 🌐 Supported Languages
 
-26 languages supported.
+27 languages supported.
 
 <details>
 <summary>Click to see all supported languages</summary>
@@ -109,6 +109,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 | 🇫🇷 | fr   | French |
 | 🇮🇳 | hi   | Hindi |
 | 🇭🇹 | ht   | Haitian Creole |
+| 🇮🇩 | id   | Indonesian |
 | 🇮🇹 | it   | Italian |
 | 🇯🇵 | ja   | Japanese |
 | 🇰🇷 | ko   | Korean |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,7 +10,7 @@ So you want to know how yasbd stacks up against the competition? Fair enough. He
 | nupunkt | Zero deps, legal-text optimized. Claims 91.1% precision at 10M chars/sec. ~12 langs. | [GitHub](https://github.com/alea-institute/nupunkt) / [pypi](https://pypi.org/project/nupunkt/) |
 | blingfire | Microsoft C++ FSM + Python bindings. Language agnostic. | [GitHub](https://github.com/microsoft/BlingFire) / [pypi](https://pypi.org/project/blingfire/) |
 | sentence-splitter | Heuristic algorithm from Europarl (Koehn/Schroeder). Archived 2025. | [GitHub](https://github.com/mediacloud/sentence-splitter) / [pypi](https://pypi.org/project/sentence-splitter/) |
-| yasbd | Pure Python, 26 langs and growing. Pointer-based SBD with pysbd adapter. | *(this repo)* |
+| yasbd | Pure Python, 27 langs and growing. Pointer-based SBD with pysbd adapter. | *(this repo)* |
 
 Not every library supports every language. We picked multiple languages that stress different weaknesses.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1324,6 +1324,7 @@ The meeting is at 2 p.m. Mwen pral vini.
   - [Russian — yasbd vs razdel](https://github.com/speedyk-005/yasbd-lib/issues/30#issuecomment-4632783363)
   - [Thai — yasbd vs Sentencex vs nupunkt vs PyThaiNLP](https://github.com/speedyk-005/yasbd-lib/pull/100#issue-4676465427)
   - [Vietnamese — yasbd vs sentencex vs nupunkt](https://github.com/speedyk-005/yasbd-lib/pull/131#issue-4779574782)
+  - [Indonesian — yasbd vs sentencex vs nupunkt](https://github.com/speedyk-005/yasbd-lib/pull/137#issue-4788758204)
 
 ## Conclusion
 

--- a/src/yasbd/rules/id.py
+++ b/src/yasbd/rules/id.py
@@ -1,0 +1,78 @@
+from yasbd.rules.base import Rules
+
+
+# fmt: off
+class IdRules(Rules):
+
+
+    TITLE_ABBRVS = Rules.TITLE_ABBRVS | {
+        # Academic, Professional, and Noble Honorifics (Prenominal Only)
+        "Ir", "Drs", "Dra", "Pdt", "H", "Hj",
+        "Sdr", "Sdri", "Bpk", "Ibu", "Kp",
+
+        # Formal Correspondence Openings & Name Truncations
+        "Yth", "Moh",
+
+        # Medical and Religious Prenominal Titles
+        "dr", "drg", "drh", "KH", "Ust", "Rm", "Ps",
+
+        # Traditional Javanese Royal Prenominal Titles
+        "R", "RA", "RM", "RB", "RP", "RAy", "Rr", "RNgt", "RNg",
+
+        # Administrative & Bureaucratic Acting Titles
+        "Pjs", "Plt",
+    }
+
+    DOTTED_GEOPOL_ABBRVS = Rules.DOTTED_GEOPOL_ABBRVS | {
+        "R.I",
+    }
+
+    REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
+        "hlm", "hal", "bab", "jil", "lamp", "ttd", "stt",
+        "cet", "terj", "dok", "pas",
+    }
+
+    SECTION_MARKERS = Rules.SECTION_MARKERS | {
+        "Bab", "Pasal", "Ayat", "Bagian", "Subbagian",
+        "Lampiran",  "Paragraf", "Sub-bab",
+    }
+
+    INLINE_ONLY_ABBRVS = Rules.INLINE_ONLY_ABBRVS | {
+        # Administrative & Postal Connectors
+        "a.n", "u.b", "d.a",
+
+        # Structural & Positional Inline Connectors
+        "a.l", "a.s", "b.d", "s.d", "u.p", "t.t", "d.h", "y.b.m",
+    }
+
+    DATE_ABBRVS = Rules.DATE_ABBRVS | {
+        # Months
+        "Agu", "Ags", "Des",
+
+        # Days
+        "Sen", "Sel", "Rab", "Kam", "Jum", "Sab", "Min",
+    }
+
+    COMMON_SENT_STARTERS = Rules.COMMON_SENT_STARTERS | {
+        # Articles
+        # (Indonesian lacks true articles; uses structural specifiers)
+        "Sang", "Si", "Para", "Kaum", "Para-",
+
+        # Pronouns & Demonstratives
+        "Saya", "Aku", "Kamu", "Dia", "Ia", "Mereka", "Kami", "Kita",
+        "Ini", "Itu",
+
+        # Adverbs & Logical Connectors
+        "Tetapi", "Namun", "Oleh karena itu", "Jadi", "Kemudian", "Lalu",
+        "Selain itu", "Bahkan", "Meskipun", "Walaupun", "Akhirnya",
+        "Pertama", "Kedua", "Ketiga",
+
+        # Question words
+        "Siapa", "Apa", "Kapan", "Di mana", "Mengapa", "Bagaimana", "Berapa",
+        "Yang mana",
+
+        # Other common starters
+        "Apakah", "Juta",
+    }
+
+# fmt: on

--- a/src/yasbd/rules/id.py
+++ b/src/yasbd/rules/id.py
@@ -6,9 +6,9 @@ class IdRules(Rules):
 
 
     TITLE_ABBRVS = Rules.TITLE_ABBRVS | {
-        # Academic, Professional, and Noble Honorifics (Prenominal Only)
+        # Academic, Professional, and Noble Honorifics
         "Ir", "Drs", "Dra", "Pdt", "H", "Hj",
-        "Sdr", "Sdri", "Bpk", "Ibu", "Kp",
+        "Sdr", "Sdri", "Bpk", "Ibu",
 
         # Formal Correspondence Openings & Name Truncations
         "Yth", "Moh",
@@ -43,6 +43,9 @@ class IdRules(Rules):
 
         # Structural & Positional Inline Connectors
         "a.l", "a.s", "b.d", "s.d", "u.p", "t.t", "d.h", "y.b.m",
+
+        # Street/Address Abbreviations
+        "Kp", "Jl", "Gg",
     }
 
     DATE_ABBRVS = Rules.DATE_ABBRVS | {

--- a/src/yasbd/rules/id.py
+++ b/src/yasbd/rules/id.py
@@ -42,7 +42,7 @@ class IdRules(Rules):
         "a.n", "u.b", "d.a",
 
         # Structural & Positional Inline Connectors
-        "a.l", "a.s", "b.d", "s.d", "u.p", "t.t", "d.h", "y.b.m",
+        "a.l", "a.s", "s.d", "u.p", "t.t", "d.h", "y.b.m",
 
         # Street/Address Abbreviations
         "Kp", "Jl", "Gg",

--- a/tests/test_data/indonesian.py
+++ b/tests/test_data/indonesian.py
@@ -1,0 +1,24 @@
+ISO_CODE = "id"
+TEST_DATA = [
+    # Basic punctuation
+    "Halo!| Apa kabar?| Baik-baik saja.",
+    "Saya pergi ke pasar.| Ibu membeli sayur.",
+
+    # Abbreviations
+    "Dr. Soekarno adalah presiden pertama.| Beliau lahir di Surabaya.",
+    "H. Abdul adalah seorang pengusaha.| Rumahnya di Jakarta.",
+    "Ir. Soekarno dan Drs. Moh. Hatta memproklamasikan kemerdekaan.",
+    "Baca hlm. 55 untuk detailnya.| Itu penting.",
+    "Beli apel, jeruk, mangga, dll.| Jangan lupa kembali.",
+
+    # Structural headings
+    "Bab 1 membahas pendahuluan.| Bab 2 membahas metode.",
+    "Pasal 5 mengatur hak dan kewajiban.| Pasal 6 mengatur sanksi.",
+
+    # Parentheses and quotes
+    "Dia berkata, \"Saya akan datang.\"| Kami menunggunya.",
+    "Hasilnya (lihat tabel 3) menunjukkan peningkatan.| Sangat signifikan.",
+
+    # Ellipsis
+    "Dia berkata... lalu pergi.",
+]


### PR DESCRIPTION
Part #20 and #132

## 🇮🇩 Yasbd vs Sentencex vs nupunkt
I tested formal Indonesian text containing geopolitical initialisms (R.I.), historical prenominal title abbreviations (Ir., Drs., Moh., Yth.), document citations (hlm., jil., Cet.), inline connectors (s.d., dkk.), and date truncations (Jan.).

Overall, **YASBD** achieved a flawless evaluation, cleanly separating the test text into logical sentence boundaries without being tripped up by language-specific trailing dots.

**Sentencex** and **nupunkt** both suffered severe over-segmentation. They aggressively fragmented sentences at almost every standard title or document marker, with **nupunkt** additionally showing unacceptable processing latency.

## Key behavioral differences:
 * **YASBD** correctly identifies and preserves localized prenominal titles like Moh. and historical reference markers like jil.
 * **Sentencex** aggressively fractures strings mid-sentence at titles (Ir., Moh.) and reference indices (hlm., jil., Cet.), while generating empty ghost segments from standard whitespace boundaries.
 * **nupunkt** exhibits identical catastrophic over-segmentation to Sentencex, while its execution time is highly impractical for processing pipelines, taking over **4.7 seconds** on a 455-character string.

<details>
<summary>Terminal outputs</summary>
YASBD | 1.9707 ms

[1]: 'Pada hari Sen. kemarin, Ir. Soekarno dan Drs. Moh. Hatta disebut kembali dalam pidato Presiden R.I.'
[2]: 'Hal ini memicu diskusi hangat di hlm. 45 buku sejarah jil. 2 yang diterbitkan oleh Cet. ke-3 PT Reksa.'
[3]: 'Yth. Bapak Direktur Utama kemudian mengonfirmasi bahwa peraturan s.d. akhir tahun tetap berlaku bagi seluruh karyawan dkk.'
[4]: 'Apakah kebijakan baru ini akan memengaruhi anggaran sebesar 50 Juta rupiah yang dialokasikan sejak Jan. lalu?'
[5]: 'Kita tunggu saja.'


Sentencex | 1.1042 ms
[1]: 'Pada hari Sen. kemarin, Ir.'
[2]: 'Soekarno dan Drs. Moh.'
[3]: 'Hatta disebut kembali dalam pidato Presiden R.I. Hal ini memicu diskusi hangat di hlm.'
[4]: '45 buku sejarah jil.'
[5]: '2 yang diterbitkan oleh Cet.'
[6]: 'ke-3 PT Reksa.'
[7]: 'Yth.'
[8]: 'Bapak Direktur Utama kemudian mengonfirmasi bahwa peraturan s.d. akhir tahun tetap berlaku bagi seluruh karyawan dkk.'
[9]: 'Apakah kebijakan baru ini akan memengaruhi anggaran sebesar 50 Juta rupiah yang dialokasikan sejak Jan. lalu?'
[10]: 'Kita tunggu saja.'
[11]: ''

nupunkt | 4790.8846 ms
[1]: 'Pada hari Sen. kemarin, Ir.'
[2]: 'Soekarno dan Drs. Moh.'
[3]: 'Hatta disebut kembali dalam pidato Presiden R.I. Hal ini memicu diskusi hangat di hlm.'
[4]: '45 buku sejarah jil.'
[5]: '2 yang diterbitkan oleh Cet.'
[6]: 'ke-3 PT Reksa.'
[7]: 'Yth.'
[8]: 'Bapak Direktur Utama kemudian mengonfirmasi bahwa peraturan s.d. akhir tahun tetap berlaku bagi seluruh karyawan dkk.'
[9]: 'Apakah kebijakan baru ini akan memengaruhi anggaran sebesar 50 Juta rupiah yang dialokasikan sejak Jan. lalu?'
[10]: 'Kita tunggu saja.'
</details>

## Summary
Add robust, comprehensive Indonesian language rules to yasbd—a Latin-script language heavily reliant on dotted bureaucratic truncations, distinct noble/academic prenominals, and unique calendar abbreviations.

## What Changed
 * New IdRules(Rules) subclass mapping comprehensive Indonesian honorifics, legal/citation structural boundaries, calendar fields, and common capital sentence starters.
 * README supported language count bumped to 27.
 
## Testing
All Indonesian regression tests pass against IdRules configuration. Core test matrix remains fully green.
