### PR TITLE
Add --from-pack CLI flag and make --lang required

### DIFF
--- a/API_REFERENCES.md
+++ b/API_REFERENCES.md
@@ -395,7 +395,7 @@ Raised when a StreamCleaner extra step fails (non-callable or non-str return).
 
 ```python
 @validate_input
-def register_lang_packs(names: list[str]) -> None
+def register_lang_packs(names: list[str]) -> list[str]
 ```
 
 Import and validate external language pack modules.
@@ -407,6 +407,9 @@ Caution:
 This function imports arbitrary Python modules by name. Only load lang
 packs from sources you trust — an untrusted module can execute
 arbitrary code at import time.
+
+**Returns**
+List of registered language codes (e.g. ``["xx", "eo"]``).
 
 **Arguments**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Persian (fa) language support** ([#128](https://github.com/speedyk-005/yasbd-lib/pull/128)).
 - **Malayalam (ml) language support** ([#124](https://github.com/speedyk-005/yasbd-lib/pull/124)).
 - **Ukrainian (uk) language support** ([#122](https://github.com/speedyk-005/yasbd-lib/pull/122)).
+- **`--from-pack` CLI flag** ([#140](https://github.com/speedyk-005/yasbd-lib/pull/140)): lets you load external language packs right from the terminal.
 
 ### Changed
 
+- **`--lang` now required** in CLI `segment` and `detect` commands ([#140](https://github.com/speedyk-005/yasbd-lib/pull/140)): dropped the default to match the Python API. Pass `--lang` explicitly or get an error.
+- **`register_lang_packs()` return type** ([#140](https://github.com/speedyk-005/yasbd-lib/pull/140)): now returns a `list[str]` of language codes instead of `None`. No more reaching into `_LANG_PACK_REGISTRY`.
 - **CJKV mixin renamed to CJK** ([#131](https://github.com/speedyk-005/yasbd-lib/pull/131)): Vietnamese uses Latin script, not CJK ideographs.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -416,6 +416,18 @@ echo "Hello. World." | yasbd segment | cat
 # Hello.
 # World.
 
+# Load external language pack and segment a mono-profile pack
+pip install yasbd-xx
+yasbd segment --from-pack yasbd_xx "Hello. World."
+# [1] 'Hello.'
+# [2] 'World.'
+
+# Multi-profile pack with explicit --lang
+pip install yasbd-auxlang
+yasbd segment --from-pack yasbd_auxlang --lang eo "Saluton. Kiel vi fartas?"
+# [1] 'Saluton.'
+# [2] 'Kiel vi fartas?'
+
 # Clean noisy text (HTML, mojibake, OCR artifacts)
 yasbd clean "<script>x</script>Hello <b>world</b>."
 # [1] 'Hello <b>world</b>.'
@@ -527,7 +539,8 @@ Need support for a language that isn't built in? Plug in your own lang pack. A l
 from yasbd.rules import register_lang_packs
 # Or from yasbd import register_lang_packs
 
-register_lang_packs(["my_yasbd_pack"])
+registered = register_lang_packs(["my_yasbd_pack"])
+print(registered)  # e.g. ["xx", "eo"]
 ```
 
 To reset the registry at runtime:

--- a/src/yasbd/cli.py
+++ b/src/yasbd/cli.py
@@ -18,6 +18,7 @@ from yasbd import (
     UnsupportedLanguageError,
     __version__,
     get_supported_langs,
+    register_lang_packs,
 )
 
 cli = Radicli(
@@ -67,6 +68,14 @@ def _stdin_is_pipe() -> bool:
 def _stdout_is_pipe() -> bool:
     """Check if stdout is a pipe (redirected to another process)."""
     return stat.S_ISFIFO(os.fstat(1).st_mode)
+
+
+def _resolve_lang(lang: Optional[str], from_pack: Optional[list[str]]) -> str | None:
+    """Register packs and resolve language. Returns lang or None."""
+    registered = register_lang_packs(from_pack) if from_pack else []
+    if lang is None and len(registered) == 1:
+        lang = registered[0]
+    return lang
 
 
 def _create_external_cleaner(
@@ -218,6 +227,7 @@ def _output(items, destination: Optional[str], *, label: str):
     file=Arg("--file", "-f", help="Read input from a text file."),
     destination=Arg("--destination", "-d", help="Write output to a file."),
     lang=Arg("--lang", "-l", help="Language code (e.g., 'en', 'fr', 'de')."),
+    from_pack=Arg("--from-pack", help="Load external language pack (repeatable)."),
     preserve_whitespace=Arg(
         "--preserve-whitespace", "-w", help="Preserve original whitespace in output."
     ),
@@ -228,6 +238,7 @@ def segment(
     file: Optional[str] = None,
     destination: Optional[str] = None,
     lang: Optional[str] = None,
+    from_pack: Optional[list[str]] = None,
     preserve_whitespace: bool = False,
     verbose: bool = False,
 ):
@@ -237,6 +248,7 @@ def segment(
     Writes enumerated sentences to stdout or JSONL to --destination.
     """
     with _resolve_input(text, file) as input_text:
+        lang = _resolve_lang(lang, from_pack)
         detector = BoundaryDetector(lang=lang, preserve_quote_and_paren=True, verbose=verbose)
         _output(
             detector.segment(input_text, preserve_whitespace=preserve_whitespace),
@@ -251,6 +263,7 @@ def segment(
     file=Arg("--file", "-f", help="Read input from a text file."),
     destination=Arg("--destination", "-d", help="Write boundary offsets to a file."),
     lang=Arg("--lang", "-l", help="Language code (e.g., 'en', 'fr', 'de')."),
+    from_pack=Arg("--from-pack", help="Load external language pack (repeatable)."),
     relative=Arg("--relative", "-r", help="Yield paragraph-relative offsets."),
     verbose=Arg("--verbose", "-v", help="Enable verbose logging."),
 )
@@ -259,6 +272,7 @@ def detect(
     file: Optional[str] = None,
     destination: Optional[str] = None,
     lang: Optional[str] = None,
+    from_pack: Optional[list[str]] = None,
     relative: bool = False,
     verbose: bool = False,
 ):
@@ -269,6 +283,7 @@ def detect(
     Use --relative for per-paragraph offsets (ParagraphEOF marks gaps).
     """
     with _resolve_input(text, file) as input_text:
+        lang = _resolve_lang(lang, from_pack)
         detector = BoundaryDetector(lang=lang, preserve_quote_and_paren=True, verbose=verbose)
         _output(
             detector.detect(input_text, relative=relative),

--- a/src/yasbd/cli.py
+++ b/src/yasbd/cli.py
@@ -13,6 +13,7 @@ from radicli import Arg, Radicli
 
 from yasbd import (
     BoundaryDetector,
+    InvalidInputError,
     ParagraphEOF,
     UnsupportedLanguageError,
     __version__,
@@ -133,12 +134,14 @@ def _resolve_input(
     if text is not None and file is not None:
         print("Error: provide text argument or --file, not both.", file=sys.stderr)
         sys.exit(1)
+
     if text is None and file is None:
         if _stdin_is_pipe():
             yield sys.stdin
             return
         print("Error: provide text argument or --file.", file=sys.stderr)
         sys.exit(1)
+
     if file is not None:
         f = open(file, encoding="utf-8")  # noqa: SIM115
         try:
@@ -162,8 +165,10 @@ def _to_json(no: int, item) -> str:
     """
     if item is ParagraphEOF:
         return json.dumps({"no": no, "eof": True})
+
     if isinstance(item, int):
         return json.dumps({"no": no, "offset": item})
+
     return json.dumps({"no": no, "text": item})
 
 
@@ -222,7 +227,7 @@ def segment(
     text: Optional[str] = None,
     file: Optional[str] = None,
     destination: Optional[str] = None,
-    lang: str = "en",
+    lang: Optional[str] = None,
     preserve_whitespace: bool = False,
     verbose: bool = False,
 ):
@@ -253,7 +258,7 @@ def detect(
     text: Optional[str] = None,
     file: Optional[str] = None,
     destination: Optional[str] = None,
-    lang: str = "en",
+    lang: Optional[str] = None,
     relative: bool = False,
     verbose: bool = False,
 ):
@@ -332,12 +337,19 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] in ("--version", "-v"):
         print(_version())
         sys.exit(0)
+
     if len(sys.argv) == 1 or (len(sys.argv) > 1 and sys.argv[1] in ("--help", "-h")):
         print(_logo_colored(), end="\n\n")
+
     try:
         cli.run()
-    except UnsupportedLanguageError as e:
+    except (UnsupportedLanguageError, InvalidInputError) as e:
         print(f"Error: {e}", file=sys.stderr)
+        if isinstance(e, InvalidInputError):
+            print(
+                "Use --lang or -l to specify a language (e.g., --lang en).",
+                file=sys.stderr,
+            )
         raise SystemExit(2) from None
 
 

--- a/src/yasbd/rules/__init__.py
+++ b/src/yasbd/rules/__init__.py
@@ -29,7 +29,7 @@ def _validate_profile(profile: type, name: str) -> None:
 
 
 @validate_input
-def register_lang_packs(names: list[str]) -> None:
+def register_lang_packs(names: list[str]) -> list[str]:
     """Import and validate external language pack modules.
 
     Each module must expose a ``PROFILES`` list of ``Rules`` subclasses.
@@ -44,9 +44,13 @@ def register_lang_packs(names: list[str]) -> None:
         names: Module names resolvable from the Python path
             (e.g. ``["yasbd_indic", "yasbd_legal"]``).
 
+    Returns:
+        List of registered language codes (e.g. ``["xx", "eo"]``).
+
     Raises:
         LangPackError: If a language pack module cannot be imported.
     """
+    registered: list[str] = []
     for name in names:
         try:
             mod = import_module(name)
@@ -69,6 +73,7 @@ def register_lang_packs(names: list[str]) -> None:
                 _validate_profile(profile, name)
                 lang_code = profile.__name__.removesuffix("Rules").lower()
                 _LANG_PACK_REGISTRY[lang_code] = (name, profile)
+                registered.append(lang_code)
             except (TypeError, RuntimeError) as e:
                 raise LangPackError(
                     f"Validation failed for {profile.__name__!r} in module {name!r}.\n"
@@ -76,6 +81,7 @@ def register_lang_packs(names: list[str]) -> None:
                 ) from e
 
     get_supported_langs.cache_clear()
+    return registered
 
 
 def clear_lang_packs() -> None:


### PR DESCRIPTION
## Summary

Add `--from-pack` flag to load external language packs from the terminal, and make `--lang` explicit in the CLI to match the Python API. `register_lang_packs()` now returns the list of registered language codes so callers don't need to reach into internals.

## What Changed

- `--lang` default removed from `segment` and `detect` commands. Pass `--lang` explicitly or get a clean error.
- `--from-pack` flag added to both commands, repeatable for multiple packs.
- Single-profile packs auto-detect the language; multi-profile packs need `--lang`.
- `register_lang_packs()` now returns `list[str]` of registered language codes instead of `None`.
- `_resolve_lang()` helper extracted to share pack registration logic between commands.

## Testing

Existing test suite stays green. Manual verification with `yasbd_xx` (mono-profile) and `yasbd_auxlang` (multi-profile) confirmed auto-detection and explicit `--lang` both work.

Closes #126 #127
