### PR TITLE
Add Swahili language support and related documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Bengali (bn) language support** ([#147](https://github.com/speedyk-005/yasbd-lib/pull/147)).
 - **Czech (cs) language support** ([#146](https://github.com/speedyk-005/yasbd-lib/pull/146)).
 - **Polish (pl) language support** ([#144](https://github.com/speedyk-005/yasbd-lib/pull/144)).
+- **Swahili (sw) language support** ([#149](https://github.com/speedyk-005/yasbd-lib/pull/149)).
 
 ## [0.9.0] - 2026-07-03
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 
 ## 🌐 Supported Languages
 
-31 languages supported.
+32 languages supported.
 
 <details>
 <summary>Click to see all supported languages</summary>
@@ -125,6 +125,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 | 🇷🇺 | ru   | Russian |
 | 🇸🇰 | sk   | Slovak |
 | 🇸🇪 | sv   | Swedish |
+| 🇹🇿 | sw   | Swahili |
 | 🇹🇭 | th   | Thai |
 | 🇺🇦 | uk   | Ukrainian |
 | 🇻🇳 | vi   | Vietnamese |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -10,7 +10,7 @@ So you want to know how yasbd stacks up against the competition? Fair enough. He
 | nupunkt | Zero deps, legal-text optimized. Claims 91.1% precision at 10M chars/sec. ~12 langs. | [GitHub](https://github.com/alea-institute/nupunkt) / [pypi](https://pypi.org/project/nupunkt/) |
 | blingfire | Microsoft C++ FSM + Python bindings. Language agnostic. | [GitHub](https://github.com/microsoft/BlingFire) / [pypi](https://pypi.org/project/blingfire/) |
 | sentence-splitter | Heuristic algorithm from Europarl (Koehn/Schroeder). Archived 2025. | [GitHub](https://github.com/mediacloud/sentence-splitter) / [pypi](https://pypi.org/project/sentence-splitter/) |
-| yasbd | Pure Python, 31 langs and growing. Pointer-based SBD with pysbd adapter. | *(this repo)* |
+| yasbd | Pure Python, 32+ langs. Pointer-based SBD with pysbd adapter. | *(this repo)* |
 
 Not every library supports every language. We picked multiple languages that stress different weaknesses.
 

--- a/src/yasbd/rules/sw.py
+++ b/src/yasbd/rules/sw.py
@@ -21,11 +21,15 @@ class SwRules(Rules):
         "mf", "m.n", "k.v", "n.k", "k.m", "ya", "taz",
     }
 
-    SECTION_MARKERS = {
+    # Swahili section headings use the pattern: [SectionWord] ya [Number]
+    # e.g., "Sura ya 1", "Sehemu ya 2", "Kifungu ya 3"
+    # "ya" is the connective particle equivalent to "of".
+    _section_markers = {
         "sura", "sehemu", "kifungu", "mwisho",
         "mlango", "Sura", "Sehemu", "Kiambatisho",
         "Hitimisho", "Utangulizi", "Dibaji",
     }
+    SECTION_MARKERS = {f"{m} ya" for m in _section_markers}
 
     DATE_ABBRVS = Rules.DATE_ABBRVS | {
         "mac", "mei", "ago", "des",

--- a/src/yasbd/rules/sw.py
+++ b/src/yasbd/rules/sw.py
@@ -1,0 +1,49 @@
+from yasbd.rules.base import Rules
+
+
+# fmt: off
+class SwRules(Rules):
+
+    TITLE_ABBRVS = Rules.TITLE_ABBRVS | {
+        "b", "n", "bw", "bi", "dkt", "mwl", "mt",
+        "mh", "nd", "mhn", "eng", "mj", "kam",
+    }
+
+    DOTTED_GEOPOL_ABBRVS = Rules.DOTTED_GEOPOL_ABBRVS | {
+        "T.Z", "D.R.C", "U.A.E",
+    }
+
+    REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
+        "uk", "sur", "jal", "har", "mf", "t.m", "n.k",
+    }
+
+    INLINE_ONLY_ABBRVS = Rules.INLINE_ONLY_ABBRVS | {
+        "mf", "m.n", "k.v", "n.k", "k.m", "ya", "taz",
+    }
+
+    SECTION_MARKERS = {
+        "sura", "sehemu", "kifungu", "mwisho",
+        "mlango", "Sura", "Sehemu", "Kiambatisho",
+        "Hitimisho", "Utangulizi", "Dibaji",
+    }
+
+    DATE_ABBRVS = Rules.DATE_ABBRVS | {
+        "mac", "mei", "ago", "des",
+    }
+
+    COMMON_SENT_STARTERS = {
+        # Pronouns
+        "Mimi", "Sisi", "Wewe", "Ninyi", "Yeye", "Wao",
+        "Huyu", "Hawa", "Huu", "Hii", "Hiki", "Hivi", "Hili", "Haya",
+        "Yule", "Wale", "Ule", "Ile", "Kile", "Vile", "Lile", "Yale",
+
+        # Question Particles
+        "Nani", "Nini", "Lini", "Wapi", "Kwanini", "Mbona", "Vipi",
+
+        # Logical Conjunctions & Transitions
+        "Kwa", "Kwa sababu", "Lakini", "Ingawa", "Kisha",
+        "Halafu", "Basi", "Isipokuwa", "Aidha", "Zaidi",
+        "Kwamba", "Hata", "Tena", "Ila", "Bali",
+    }
+
+# fmt: on

--- a/tests/test_data/swahili.py
+++ b/tests/test_data/swahili.py
@@ -1,0 +1,23 @@
+ISO_CODE = "sw"
+TEST_DATA = [
+    # Basic punctuation
+    "Habari za asubuhi.| Habari za jioni.",
+    "Unaitwa nani?| Ninaitwa Juma.",
+    "Hongera!| Umefanya vizuri.",
+
+    # Abbreviations
+    "Bw. Juma amefika.| Yuko ofisini.",
+    "Bi. Asha ni mwalimu.| Anafundisha shuleni.",
+    "Mh. Rais atazungumza kesho.| Wananchi wanasubiri.",
+    "Ndugu Wanjala alikaribishwa.| Alishukuru wote.",
+    "Eng. Njoroge anaendesha mradi.| Yeye ni mhandisi.",
+    "Mj. wa Kamati alitoa taarifa.| Kamati ilikubali.",
+    "Dkt. Mwangi atawasili kesho.| Ana mkutano saa tatu.",
+
+    # Parentheses and quotes
+    'Aliuliza "Unafanya nini?"| Nilijibu "Ninasoma."',
+    "Anakula matunda (maembe na ndizi).| Yeye ni hodari.",
+
+    # Ellipsis
+    "Alisema... sijui.| Kisha akaondoka.",
+]

--- a/tests/test_data/swahili.py
+++ b/tests/test_data/swahili.py
@@ -1,9 +1,9 @@
 ISO_CODE = "sw"
 TEST_DATA = [
     # Basic punctuation
-    "Habari za asubuhi.| Habari za jioni.",
-    "Unaitwa nani?| Ninaitwa Juma.",
-    "Hongera!| Umefanya vizuri.",
+    "Habari za asubuhi.| Habari za jioni.| Leo ni siku nzuri.",
+    "Unaitwa nani?| Ninaitwa Juma.| Nimefurahi kukutana nawe.",
+    "Hongera!| Umefanya vizuri sana.| Endelea vivyo hivyo.",
 
     # Abbreviations
     "Bw. Juma amefika.| Yuko ofisini.",
@@ -13,11 +13,20 @@ TEST_DATA = [
     "Eng. Njoroge anaendesha mradi.| Yeye ni mhandisi.",
     "Mj. wa Kamati alitoa taarifa.| Kamati ilikubali.",
     "Dkt. Mwangi atawasili kesho.| Ana mkutano saa tatu.",
+    "Mwl. Hassan anafundisha Kiswahili.| Wanafunzi wanamwapenda.",
+
+    # Structural headings
+    "Sura ya 1. Utangulizi.| Ilikuwa usiku wa giza.",
+    "Sehemu ya 2. Uchambuzi.| Mfumo unaanza hapa.",
+    "Data zilithibitishwa.| Sura ya 4. Mbinu.",
 
     # Parentheses and quotes
     'Aliuliza "Unafanya nini?"| Nilijibu "Ninasoma."',
     "Anakula matunda (maembe na ndizi).| Yeye ni hodari.",
+    'Alisema: "Habari za leo! Mimi ni Juma. Na wewe?"',
+    'Aligeuka akamwambia, "Ni nzuri." akasema.',
 
     # Ellipsis
-    "Alisema... sijui.| Kisha akaondoka.",
+    "Mradi ulikuwa karibu kukamilika... lakini tukapata tatizo.",
+    'Aliuliza: "Tumekoseaje!..."| Kisha akaondoka.',
 ]


### PR DESCRIPTION
Part #20 and #132

### Summary

Add Swahili (sw) language support — Latin script, inherits from `Rules`.

### What Changed

- Swahili-specific title abbreviations (`Bw.`, `Bi.`, `Mh.`, `Mwl.`, `Eng.`, `Mj.`, `Dkt.`, etc.), geopolitical abbreviations (`T.Z`, `D.R.C`), reference abbreviations, inline-only abbreviations (connective discourse markers), date abbreviations, and common sentence starters.
- Composite `SECTION_MARKERS` pattern using `"ya"` connective to protect Swahili section headings (`Sura ya 1.`, `Sehemu ya 2.`, etc.).
- 20 test cases covering basic punctuation, abbreviations, structural headings, parentheses, quotes, and ellipsis.
- README language count bumped to 32.

### Testing

Full suite passes (20 Swahili subtests, no regressions).
