### PR TITLE
Fix non-German ordinal boundary inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Clock abbreviations** ([#152](https://github.com/speedyk-005/yasbd-lib/pull/152)): protect kl, hod, год from false sentence boundaries in cs, sk, uk, sv.
+- **Non-German ordinal boundary inheritance** ([#153](https://github.com/speedyk-005/yasbd-lib/pull/153)): remove inherited German ordinal pattern from nl, sv, da, af to fix false negatives on numbered sentence boundaries.
 
 ## [0.9.0] - 2026-07-03
 

--- a/README.md
+++ b/README.md
@@ -585,6 +585,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@sanmaxdev](https://github.com/sanmaxdev)** | Language tag normalization helper |
 | **[@hongquan](https://github.com/hongquan)** | `py.typed` marker for PEP 561 compliance |
 | **[@terminalchai](https://github.com/terminalchai)** | Burmese and Thai reporting words fix |
+| **[kernelpanic888](https://github.com/kernelpanic888)** | Non-German ordinal boundary inheritance fix |
 | **[@1cbyc](https://github.com/1cbyc)** | Coordinate direction abbreviation fix |
 
 Interested in contributing? See the [**Contributing Guide**](https://github.com/speedyk-005/yasbd-lib/blob/main/CONTRIBUTING.md) to get started!

--- a/src/yasbd/rules/nl.py
+++ b/src/yasbd/rules/nl.py
@@ -97,4 +97,14 @@ class NlRules(DeRules):
         "zaterdag", "zondag",
      }
 
+    @classmethod
+    def _compile_regex_dynamically(cls):
+        """Remove the German ordinal guard inherited from DeRules."""
+        super()._compile_regex_dynamically()
+        cls.MID_SENTENCE_FINDER_LST = [
+            pattern
+            for pattern in cls.MID_SENTENCE_FINDER_LST
+            if pattern.pattern != r"\s\d{1,3}\."
+        ]
+
 # fmt: on

--- a/src/yasbd/rules/sv.py
+++ b/src/yasbd/rules/sv.py
@@ -71,4 +71,14 @@ class SvRules(DeRules):
         "lördag", "söndag",
      }
 
+    @classmethod
+    def _compile_regex_dynamically(cls):
+        """Remove the German ordinal guard inherited from DeRules."""
+        super()._compile_regex_dynamically()
+        cls.MID_SENTENCE_FINDER_LST = [
+            pattern
+            for pattern in cls.MID_SENTENCE_FINDER_LST
+            if pattern.pattern != r"\s\d{1,3}\."
+        ]
+
 # fmt: on

--- a/tests/test_data/afrikaans.py
+++ b/tests/test_data/afrikaans.py
@@ -15,6 +15,7 @@ TEST_DATA = [
     "Die verslag is in des. gepubliseer.| Dit is deur prof. Smit en mnr. Nel goedgekeur.",
     "Sien afb. 2 in deel 3, hfst. 4, bl. 18-22.",
     "Ons sien mekaar op vr. 14 Feb.",
+    "Die vergadering is om 14.| Vandag bespreek ons die besonderhede.",
     "Die V.S. regering het 'n nuwe wet aangeneem.",
 
     # Structural headings

--- a/tests/test_data/danish.py
+++ b/tests/test_data/danish.py
@@ -19,6 +19,7 @@ TEST_DATA = [
     "Han bor i U.S.A. i 20 år.| Nu bor han i E.U.",
     "Mødet er aflyst pga. sygdom.",
     "Han sagde bl.a. at det var vigtigt.",
+    "Mødet er kl. 14.| I dag er det tirsdag.",
 
     # Quoted speech
     'Hun vender sig mod ham: "Det er vidunderligt."| Hun rækker ham bogen.',

--- a/tests/test_data/dutch.py
+++ b/tests/test_data/dutch.py
@@ -19,6 +19,7 @@ TEST_DATA = [
     "We zien elkaar op vr. 14 feb.",
     "U vindt het onder nr. 1026.253.553.| Daar ligt de schat.",
     "We kiezen eerst optie A.| Daarna bespreken we de details.",
+    "De vergadering begint om 14.| Vandaag bespreken we de details.",
 
     # Structural headings
     "Hoofdstuk 1. Het begin.| Het was donker en stil in de kamer.| Niets bewoog.",

--- a/tests/test_data/swedish.py
+++ b/tests/test_data/swedish.py
@@ -19,6 +19,7 @@ TEST_DATA = [
     "Han bor i USA i 20 år.| Nu bor han i EU.",
     "Mötet ställdes in pga. sjukdom.",
     "Han sa bl.a. att det var viktigt.",
+    "Mötet är 14.| Idag är det tisdag.",
 
     # Quoted speech
     'Hon vänder sig mot honom: "Det är fantastiskt."| Hon räcker honom boken.',


### PR DESCRIPTION
### Objective

Fixes #151.

Swedish, Danish, Dutch, and Afrikaans inherit from the German rules, but they do not share the same capitalization ambiguity around numeric ordinals. A number followed by an uppercase word can be a normal sentence boundary in these languages, so the German ordinal guard should not block that split for them.

### Changes

- Override dynamic regex compilation in `SvRules` and `NlRules` to remove the inherited German ordinal guard.
- Let `DaRules` and `AfRules` inherit the corrected behavior through their existing parent classes.
- Add regression cases for Swedish, Danish, Dutch, and Afrikaans numbered-sentence boundaries.

### Verification

- `.venv/bin/python -m pytest`
- `.venv/bin/ruff format src/ --check`
- `.venv/bin/ruff check src/`

