### PR TITLE
Fix nested quote boundary leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Clock abbreviations** ([#152](https://github.com/speedyk-005/yasbd-lib/pull/152)): protect kl, hod, год from false sentence boundaries in cs, sk, uk, sv.
 - **Non-German ordinal boundary inheritance** ([#153](https://github.com/speedyk-005/yasbd-lib/pull/153)): remove inherited German ordinal pattern from nl, sv, da, af to fix false negatives on numbered sentence boundaries.
+- **Nested quote boundary leak** ([#156](https://github.com/speedyk-005/yasbd-lib/pull/156)): prevent inner single quotes inside double quotes from creating false sentence boundaries.
 
 ## [0.9.0] - 2026-07-03
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -343,13 +343,15 @@ class Rules:
         if preserve_quote_and_paren:
             # Ignore first pos to preserve splits before opening quote/paren,
             # especially for non-whitespace languages
-            sentence_boundaries.difference_update(
+            inner_range = {
                 pos for m in self.QUOTE_AND_PAREN_FINDER.finditer(text)
                 for pos in range(m.start() + 1, m.end())
-            )
+            }
+            sentence_boundaries.difference_update(inner_range)
 
             sentence_boundaries.update(
                 m.end() for m in self.QUOTE_AND_PAREN_END_FINDER.finditer(text)
+                if m.end() not in inner_range
             )
 
     def _remove_toc_spans(

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -66,6 +66,7 @@ TEST_DATA = [
     'Then he stop.| "wait" he said',
     "The letter concluded with a simple warning: 'Do not follow me.'| Then she left.",
     'He said: "First sentence. Second sentence."| Then done.',
+    'The witness testified: "He said — and I quote — \'I will not comply.\' Then he turned around and left. I could not believe it."',
 
     # Contiguous terminators
     "Hello ! ! ! !",


### PR DESCRIPTION
### Objective

Nested single quotes inside double quotes (e.g. `'I will not comply.'` inside `"..."`) were creating false sentence boundaries. The quote end finder was re-adding boundaries for inner terminators even when they fell inside an outer quote span.

### Changes

- Pre-compute positions inside quote/paren spans and skip `QUOTE_AND_PAREN_END_FINDER` boundaries that land inside them.
- Added nested quote test case to English test data.

### Verification

- `pytest tests/test_boundary_detector.py -k "test_segment_multiple_langs and en-"` passes (95 subtests).

### Related Issues

Fixes #156