### PR TITLE
Fix false sentence boundary triggered by & character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Clock abbreviations** ([#152](https://github.com/speedyk-005/yasbd-lib/pull/152)): protect kl, hod, год from false sentence boundaries in cs, sk, uk, sv.
 - **Non-German ordinal boundary inheritance** ([#153](https://github.com/speedyk-005/yasbd-lib/pull/153)): remove inherited German ordinal pattern from nl, sv, da, af to fix false negatives on numbered sentence boundaries.
 - **Nested quote boundary leak** ([#156](https://github.com/speedyk-005/yasbd-lib/pull/156)): prevent inner single quotes inside double quotes from creating false sentence boundaries.
+- **`&` after title abbreviation** ([#157](https://github.com/speedyk-005/yasbd-lib/pull/157)): prevent & from triggering false sentence boundary after Com. or similar title abbreviations.
 
 ## [0.9.0] - 2026-07-03
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -246,7 +246,7 @@ class Rules:
                 (?<={cls.TERMINATORS_PATTERN}(?!\s*\p{{Emoji_Presentation}}))
                 (?=
                     \s*[\n\p{{Lo}}]|
-                    \s+(?:[^\p{{Ll}}]|
+                    \s+(?:[^\p{{Ll}}&]|
                     \s+(?<!\.\.)(?i:{cls.COMMON_STARTERS_PATTERN})\b)
                )|
 

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -68,6 +68,9 @@ TEST_DATA = [
     'He said: "First sentence. Second sentence."| Then done.',
     'The witness testified: "He said — and I quote — \'I will not comply.\' Then he turned around and left. I could not believe it."',
 
+    # "&" separator (fix for #150)
+    'Trying to get back to Com. & Adm. through the most direct path in the dark.',
+
     # Contiguous terminators
     "Hello ! ! ! !",
     "Hello!!| Long time no see.",


### PR DESCRIPTION
### Objective

"Com. & Adm." was incorrectly split into two sentences because "&" matched the sentence starter pattern ("[^\p{Ll}]") in "CANDIDATE_BOUNDARY_FINDER". This caused a false sentence boundary to be detected after title abbreviations.

### Changes

- Excluded "&" from the sentence starter character class in "CANDIDATE_BOUNDARY_FINDER" to prevent it from triggering a false sentence boundary.
- Added an English test case covering "Com. & Adm.".

### Verification

- "pytest tests/test_boundary_detector.py -k "test_segment_multiple_langs and en-"" passes.
- Added a regression test confirming that "Com. & Adm." remains a single sentence.
- Existing tests continue to pass.

### Related Issues

Fixes #150.