### PR TITLE
Fix false sentence boundary caused by name initials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Non-German ordinal boundary inheritance** ([#153](https://github.com/speedyk-005/yasbd-lib/pull/153)): remove inherited German ordinal pattern from nl, sv, da, af to fix false negatives on numbered sentence boundaries.
 - **Nested quote boundary leak** ([#156](https://github.com/speedyk-005/yasbd-lib/pull/156)): prevent inner single quotes inside double quotes from creating false sentence boundaries.
 - **`&` after title abbreviation** ([#157](https://github.com/speedyk-005/yasbd-lib/pull/157)): prevent & from triggering false sentence boundary after Com. or similar title abbreviations.
+- **Name initials at start of text** ([#160](https://github.com/speedyk-005/yasbd-lib/pull/160)): prevent `A. B. Smith` from being split by horizontal list marker pattern.
 
 ## [0.9.0] - 2026-07-03
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -212,12 +212,13 @@ class Rules:
         cls.DOTTED_GEOPOL_ABBRVS_PATTERN = build_abbr_pattern(cls.DOTTED_GEOPOL_ABBRVS)
         cls.COMMON_STARTERS_PATTERN = build_abbr_pattern(cls.COMMON_SENT_STARTERS)
 
-        # https://regex101.com/r/qBSyU5/16
+        # https://regex101.com/r/qBSyU5/19
         # Handle flattened lists due to messy OCR.
         cls.HORIZONTAL_LIST_FINDER = re2.compile(
             rf"""
-            # Must preceded by string or word boundary
-            (?:^|(?<![A-Z]\w+)\s+)
+            # Must preceded by string start or word boundary
+            # while skipping initialisms 
+            (?:^|(?<![A-Z](?:\.|\w+))\s+)
             (?:[•◦]\s+)?   # Optional bullet point (e.g., • 9.)
             (?:
                 [-*+]|      #  Markdown style list
@@ -226,9 +227,14 @@ class Rules:
                 (?:\d{{1,2}}|[a-eA-Eα-εΑ-Εа-еА-Е])
                 (?:{cls.DOT_LIKE_PATTERN}|\)){{1,2}}
             )
-            (?=\s)  # Must followed by a space
-            """,
-            re2.X,
+
+            # Must be followed by whitespace
+            # Numeric markers only require whitespace
+            # Alphabetic markers must not be name initials (e.g. "A. B. Smith")
+            (?:
+                (?<=\d\.)(?=\s)|(?=\s+(?!\p{{LU}}\.))
+            )
+            """, re2.X,
         )
 
         # https://regex101.com/r/VMzYsx/10
@@ -377,6 +383,7 @@ class Rules:
 
         if is_flattened_list:
             sentence_boundaries.difference_update(m.end() for m in horiz_matches)
+
             # Shift boundaries back (1.\)| => |1.\), a. | => |a. ) to correctly
             # terminate the preceding sentence before flattened horizontal list.
             sentence_boundaries.update(m.start() + 1 for m in horiz_matches if m.start())

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -217,7 +217,7 @@ class Rules:
         cls.HORIZONTAL_LIST_FINDER = re2.compile(
             rf"""
             # Must preceded by string start or word boundary
-            # while skipping initialisms 
+            # while skipping initialisms
             (?:^|(?<![A-Z](?:\.|\w+))\s+)
             (?:[•◦]\s+)?   # Optional bullet point (e.g., • 9.)
             (?:

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -10,6 +10,7 @@ TEST_DATA = [
 
     # -- Abbreviations --
     "My name is Jonas E. Smith.",
+    "A. B. Smith graduated from Harvard.| He then worked from IBM Corp.",
     "Please turn to p. 55.",
     "Were Jane and co. at the party?",
     "They closed the deal with Pitt, Briggs & Co. at noon.",
@@ -83,6 +84,8 @@ TEST_DATA = [
     "1. The first item.| 2. The second item.",
     "• 9. The first item.| • 10. The second item.",
     "a. The first item |b. The second item",
+    "A. I am a king.| B. You are a prince.",
+    "A. ananas| B. banana.",
 
     # Not a list (fix for #52)
     "I really want letter A.| I know that I asked you for the B.| I changed my mind.",


### PR DESCRIPTION
### Objective

`A. B. Smith` at start of text was getting split into two sentences. The list marker pattern matched single-letter name initials, and the `(?<=\.)` lookbehind couldn't catch `A.` at position 0.

### Changes

- Tightened `HORIZONTAL_LIST_FINDER` so alphabetic list markers (items like `A.`, `B.`) don't match single-letter name initials. Numeric markers still work the same.
- Added `A. B. Smith` test case to English data.

### Verification

- All 95 English tests pass.