### PR TITLE
Add Lithuanian language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Brand/snack exclamation entries**: Crunch and Banga added to `NAMES_WITH_EXCLAMATION`.
 - **Set literal reformatting script** ([#165](https://github.com/speedyk-005/yasbd-lib/pull/165)): `scripts/reformat_sets.py` automatically balances set items to ≤70 chars per line.
+- **Lithuanian (lt) language support** ([#167](https://github.com/speedyk-005/yasbd-lib/pull/167)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Brand/snack exclamation entries**: Crunch and Banga added to `NAMES_WITH_EXCLAMATION`.
 - **Set literal reformatting script** ([#165](https://github.com/speedyk-005/yasbd-lib/pull/165)): `scripts/reformat_sets.py` automatically balances set items to ≤70 chars per line.
-- **Lithuanian (lt) language support** ([#167](https://github.com/speedyk-005/yasbd-lib/pull/167)).
+- **Lithuanian (lt) language support** ([#168](https://github.com/speedyk-005/yasbd-lib/pull/168)).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 
 ## 🌐 Supported Languages ([API](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbdrules))
 
-33 languages supported.
+34 languages supported.
 
 <details>
 <summary>Click to see all supported languages</summary>
@@ -116,6 +116,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 | 🇮🇹 | it   | Italian |
 | 🇯🇵 | ja   | Japanese |
 | 🇰🇷 | ko   | Korean |
+| 🇱🇹 | lt   | Lithuanian |
 | 🇮🇳 | ml   | Malayalam |
 | 🇮🇳 | mr   | Marathi |
 | 🇲🇲 | my   | Burmese |

--- a/src/yasbd/rules/lt.py
+++ b/src/yasbd/rules/lt.py
@@ -1,0 +1,84 @@
+import regex as re
+
+from yasbd.rules.base import Rules
+
+
+# fmt: off
+class LtRules(Rules):
+    """Sentence boundary detection rules for the Lithuanian language.
+
+    Defines the language-specific token arrays required to accurately parse
+    sentence boundaries in Lithuanian prose, handling complex dotted
+    abbreviations, citations, and inline tokens.
+    """
+
+    TITLE_ABBRVS = Rules.TITLE_ABBRVS | {
+        # Respectful & Social Address
+        "p", "pon", "ponia", "ponios", "panelė", "pan", "gerb", "šv",
+
+        # Academic & Professional
+        "doc", "akad", "habil", "inž", "arch", "gyd", "teis",
+
+        # Military, Clergy & Clerical Titles
+        "gen", "plk", "mjr", "kpt", "ltn", "kun", "prel", "vysk",
+    }
+
+    DOTTED_GEOPOL_ABBRVS = Rules.DOTTED_GEOPOL_ABBRVS | {
+        "L.R", "J.A.V", "E.S", "U.R.M", "V.R.M", "S.A.D.M",
+    }
+
+    REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
+        # Bibliographical & Citation Indicators
+        # (Typically precede numbers/values)
+        "t", "l", "psl", "str", "skyr", "pav", "lent", "sk",
+        "red", "leid", "žr", "plg", "pvz", "nr", "egz",
+        "t.t", "ir kt",
+    }
+
+    INLINE_ONLY_ABBRVS = Rules.INLINE_ONLY_ABBRVS | {
+        "t.y", "š.m", "b.m", "g", "pr",
+    }
+
+    SECTION_MARKERS = Rules.SECTION_MARKERS | {
+        "Skyrius", "Poskyris", "Priedas", "Lentelė",
+        "Paveikslas", "Įvadas", "Išvados"
+    }
+
+    DATE_ABBRVS = {
+        # Months
+        "saus", "vas", "kov", "bal", "geg", "birž",
+        "liep", "rugp", "rugs", "spal", "lapkr", "gruod",
+
+        # Days (Used in running prose)
+        "pirm", "antr", "treč", "ketv", "penkt", "šešt", "sekm",
+    }
+
+    COMMON_SENT_STARTERS = {
+        # Pronouns
+        "Aš", "Ji", "Jie", "Jis", "Jos", "Jūs", "Kas", "Koks",
+        "Mes", "Tai", "Tu", "Ši", "Šis",
+
+        # Logical Connectors & Adverbs
+        "Antra", "Be", "Beje", "Bet", "Dabar", "Jeigu",
+        "Kadangi", "Kai", "Nors", "Pirmiausia", "Tada",
+        "Tačiau", "Todėl", "Vėliau", "Štai",
+    }
+
+    # fmt: on
+    @classmethod
+    def _compile_regex_dynamically(cls):
+        """Override base regex compilation to handle single letter abbrvs."""
+        super()._compile_regex_dynamically()
+
+        cls.MID_SENTENCE_FINDER_LST.append(
+            re.compile(
+                rf"""
+                # A lowercase letter + dot  followed by any char + dot
+                (?<=[a-ząčęėįšųūž]\.)(?=\s+.\.)|
+
+                # A number or any char + dot
+                # followed by space + lowercase letter + dot
+                (?<=(?:\d|.\.)\s+[a-ząčęėįšųūž]\.)
+                """, re.X
+            )
+        )

--- a/src/yasbd/rules/lt.py
+++ b/src/yasbd/rules/lt.py
@@ -72,7 +72,7 @@ class LtRules(Rules):
 
         cls.MID_SENTENCE_FINDER_LST.append(
             re.compile(
-                rf"""
+                r"""
                 # A lowercase letter + dot  followed by any char + dot
                 (?<=[a-ząčęėįšųūž]\.)(?=\s+.\.)|
 

--- a/tests/test_data/lithuanian.py
+++ b/tests/test_data/lithuanian.py
@@ -1,0 +1,56 @@
+ISO_CODE = "lt"
+TEST_DATA = [
+    # Basic punctuation
+    "Labas pasauli!| Kaip tu?| Man viskas gerai.",
+    "Koks tavo vardas?| Mano vardas Jonas.",
+    "Štai ir jis!| Pagaliau jį radau.",
+
+    # Abbreviations
+    "Mano vardas yra L. P. Kazlauskas.",
+    "Prof. dr. Kazlauskas yra žinomas mokslininkas.",
+    "Dokumentą rasite p. 55.",
+    "Žr. pav. 3 skyrelyje 5.",
+    "Leidinys publikuotas t. II tome.",
+    "Ataskaita buvo paskelbta 2024 saus.",
+    "Ji atvyko pn. ryte.",
+    "Jis gyvena Pergalės g. 12.",
+    "Studentų atstovybė posėdžiavo Trečiadienį, 15 lapkr.",
+    "Tyrimas atliktas 2023 m. ir apima 5 metų laikotarpį.",
+    "Lent. 1 pateikia duomenų suvestinę.| Rezultatai aiškiai matomi.",
+    "Buvo ištirta 10 skirtingų rūšių, t. y. visi Lietuvoje aptinkami pavyzdžiai.",
+    "Rinkoje siūloma daug įvairių produktų, pvz., ekologiški užkandžiai.",
+    "Palyginkite šiuos du metodus, plg. 3 ir 4 lenteles.",
+    "Straipsnį parašė doc. dr. A. Petraitis.",
+    "Į sutartį įtrauktos kelios dalys, ir kt. punktai.",
+    "Nurodyti kiekiai pateikiami tonomis (tūkst. t).",
+    "Įmonės apyvarta siekia 5 mln. eurų.",
+    "Biudžetas viršija 2 mlrd. litų.",
+    "Jis turi habil. dr. laipsnį iš gamtos mokslų.",
+    "Viešbutyje apsistojome 2024 gruod. 12 d.",
+
+    # Structural headings
+    "Skyrius 1. Pradžia.| Būtų tamsu ir tylu.| Niekas nejudėjo.",
+    "Poskyris 3.1. Tyrimo apimtis.| Projektas apima tris kalbas.",
+    "Rezultatai nebuvo vienareikšmiai.| Skyrius 4. Diskusija.| Komanda peržiūrėjo modelį.",
+    "Priedas A. Klausimynas.| Visi respondentai užpildė anketą.",
+    "Lentelė 5. Duomenų analizė.| Išvados pateikiamos toliau.",
+    "Išvados.| Tyrimas parodė reikšmingus skirtumus.| Rekomenduojama tęsti stebėjimus.",
+
+    # Parentheses and quotes
+    "Jis dėsto gamtos mokslus (anksčiau 5 metus dirbo inžinieriumi) vietiniame universitete.",
+    "(Žr. pav. 4. Čia pateikiama atminties schema.)| Sistema atlieka kitą veiksmą.",
+    'Ji atsisuko į jį: „Ar tai tiesa?“| Jis linktelėjo galva.',
+    '„Čia nuostabu“, – pasakė ji.',
+    '„Palauk“, – tarė jis.',
+    'Laiškas baigėsi paprastu perspėjimu: „Nesek manęs.“| Tada ji išėjo.',
+    "Jis pasakė: „Pirmas sakinys. Antras sakinys.“| Tada jis užsidarė.",
+    'Ką ji pasakė?| „Aš ateisiu vėliau.“| Tai buvo viskas.',
+    "Knyga buvo išleista 1985 m. [ar 1984?], bet autorius ją baigė 1990 m.",
+    "Direktorius atsakė: „Pirmadienį. 15 val.“| Tai buvo konkretus atsakymas.",
+
+    # Ellipsis
+    "Projektas buvo beveik baigtas... ar bent jau mes taip manėme.",
+    '„Kaip mes galėjome to nepastebėti!...“| Tomas sušuko ir trenkė kumščiu į stalą.',
+    "Mes radome klaidą sistemoje....| Ji buvo subtili.",
+    "Jis pagalvojo...| Tada jis atsakė.",
+]


### PR DESCRIPTION
Part #20 and #132

## Summary

Add Lithuanian (lt) as a built-in language. Baltic family, inherits from `Rules`. 34 languages now.

## What Changed

- New `lt.py` rule file with Lithuanian-specific title, reference, date, and inline abbreviation sets
- New `lithuanian.py` test data with real-world sentences covering punctuation, abbreviations, headings, quotes, and ellipsis
- README language count bumped to 34, table row added
- CHANGELOG updated

## Testing

- `pytest tests/test_boundary_detector.py -k "lt-"` passes
- Full suite green, no regressions
