### PR TITLE
Fix overly permissive flattened list heuristic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flattened list heuristic** ([#169](https://github.com/speedyk-005/yasbd-lib/pull/169)): pairwise proximity check prevents false positives from randomly spaced horizontal markers.
 - **Removed ambiguous shared abbreviations** ([#166](https://github.com/speedyk-005/yasbd-lib/pull/166)): `est`, `dist`, `misc`, `tel` removed from base `INLINE_ONLY_ABBRVS`. French also excludes `est` from reference abbreviations.
 - **HTML markup leaking through cleaner** ([#162](https://github.com/speedyk-005/yasbd-lib/pull/162)): doctype declarations, comments, and processing instructions no longer pass through. Void elements removed from content-stripping group. Math expressions like `x < 5 and y > 3` no longer mangled.
 

--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@1cbyc](https://github.com/1cbyc)** | Coordinate direction abbreviation fix |
 | **[@kernelpanic888](https://github.com/kernelpanic888)** | Non-German ordinal boundary inheritance fix |
 | **[@hkJerryLeung](https://github.com/hkJerryLeung)** | French `est` abbreviation fix |
+| **[@Mayankshrey438](https://github.com/Mayankshrey438)** | Flattened list proximity heuristic |
 
 </details>
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -1,4 +1,5 @@
 import re  # For simpler patterns
+from itertools import pairwise
 
 import regex as re2
 from retrie.trie import Trie
@@ -382,14 +383,19 @@ class Rules:
 
         # Quick contextual heuristic
         is_flattened_list = (
+            # A flattened list must contain at least two horizontal markers
             len(horiz_matches) >= 2
             and (
+                # List is introduced by a colon
+                # or starts directly at the beginning of the text
                 ":" in text
                 or text[horiz_matches[0].start()] == text.lstrip()[0]
             )
+
+            # List markers are close enough to belong to the same flattened list
             and all(
                 b.start() - a.end() < 40
-                for a, b in zip(horiz_matches, horiz_matches[1:])
+                for a, b in pairwise(horiz_matches)
             )
         )
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -387,6 +387,10 @@ class Rules:
                 ":" in text
                 or text[horiz_matches[0].start()] == text.lstrip()[0]
             )
+            and all(
+                b.start() - a.end() < 40
+                for a, b in zip(horiz_matches, horiz_matches[1:])
+            )
         )
 
         if is_flattened_list:


### PR DESCRIPTION
**Objective**

Fix the flattened list heuristic so unrelated list markers are not incorrectly treated as part of the same flattened list.

Fixes #167

**Changes**

- Added a distance check between consecutive horizontal list markers.
- Prevents false positives when distant markers are incorrectly classified as a flattened list.
- Preserves existing behavior for valid flattened lists.

**Verification**

- Ran the full test suite.
- Result: 72 passed, 2 skipped.