### PR TITLE
Fix typos and update installation instructions in README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Pull the official schematics from the main repository:
 
 ```bash
 git clone https://github.com/speedyk-005/yasbd-lib.git
-cd yasbd
+cd yasbd-lib
 ```
 
 ### Calibrate the Environment
@@ -98,7 +98,6 @@ This runs `ruff` on every commit so you never forget.
 If you changed any docstrings or public interfaces, regenerate the docs:
 
 ```bash
-pip install -e ".[dev]"
 
 # Generate API_REFERENCES.md from docstrings
 bash scripts/gen_api_docs.sh

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,5 +16,6 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@hkJerryLeung](https://github.com/hkJerryLeung)** | French `est` abbreviation fix |
 | **[@Mayankshrey438](https://github.com/Mayankshrey438)** | Flattened list proximity heuristic |
 | **[@cnaples79](https://github.com/cnaples79)** | Missing commas in set literals (silent concatenation fix) |
+| **[@JosephM961](https://github.com/JosephM961)** | Documentation typos and stale path fixes |
 
 Interested in contributing? See the [**Contributing Guide**](CONTRIBUTING.md) to get started!

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 - Geopolitical + case markers
 - Quote/parenthesis span filtering
 - TOC leader suppression
-- List marker re-alignmen
+- List marker re-alignment
 - Contiguous terminator collapsing
-- Language specifical final fixups
+- Language-specific final fixups
 
 ---
 
@@ -182,7 +182,7 @@ Prefer building from source? Clone and install manually for full control:
 
 ```bash
 git clone https://github.com/speedyk-005/yasbd-lib.git
-cd yasbd
+cd yasbd-lib
 pip install .
 ```
 


### PR DESCRIPTION
## Objective

Correct typos and inconsistent installation instructions in the project documentation.

## Changes

- Corrected typos in `README.md`

- Fixed the clone directory and installation instructions

- Corrected the `cd yasbd` command to `cd yasbd-lib` in `CONTRIBUTING.md`

- Removed the duplicated `pip install -e ".[dev]"` instruction

## Verification

- Reviewed the updated Markdown files for accuracy and formatting

- Confirmed that all automated checks passed

- No code changes were made, so no additional tests were required

## Related Issues

- Fixes #176