### PR TITLE
docs: fix typos in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Pull the official schematics from the main repository:
 
 ```bash
 git clone https://github.com/speedyk-005/yasbd-lib.git
-cd yasbd
+cd yasbd-lib
 ```
 
 ### Calibrate the Environment
@@ -98,8 +98,6 @@ This runs `ruff` on every commit so you never forget.
 If you changed any docstrings or public interfaces, regenerate the docs:
 
 ```bash
-pip install -e ".[dev]"
-
 # Generate API_REFERENCES.md from docstrings
 bash scripts/gen_api_docs.sh
 ```

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 - Geopolitical + case markers
 - Quote/parenthesis span filtering
 - TOC leader suppression
-- List marker re-alignmen
+- List marker re-alignment
 - Contiguous terminator collapsing
-- Language specifical final fixups
+- Language-specific final fixups
 
 ---
 
@@ -182,7 +182,7 @@ Prefer building from source? Clone and install manually for full control:
 
 ```bash
 git clone https://github.com/speedyk-005/yasbd-lib.git
-cd yasbd
+cd yasbd-lib
 pip install .
 ```
 


### PR DESCRIPTION
## Summary
- Fixes truncated words in README.md: "re-alignmen" -> "re-alignment", "Language specifical final fixups" -> "Language-specific final fixups"
- Fixes `cd yasbd` -> `cd yasbd-lib` in both README.md and CONTRIBUTING.md (the clone command actually creates a `yasbd-lib` directory)
- Removes the redundant duplicate `pip install -e ".[dev]"` step in CONTRIBUTING.md's "Build Documentation" section (already installed in "Bench Setup")

## Test plan
- Docs-only change, no code affected
- Visually diffed against the exact list of typos reported in #176

Fixes #176