### PR TITLE
Add Turkish language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Brand/snack exclamation entries**: Crunch and Banga added to `NAMES_WITH_EXCLAMATION`.
 - **Set literal reformatting script** ([#165](https://github.com/speedyk-005/yasbd-lib/pull/165)): `scripts/reformat_sets.py` automatically balances set items to ≤70 chars per line.
 - **Lithuanian (lt) language support** ([#168](https://github.com/speedyk-005/yasbd-lib/pull/168)).
+- **Turkish (tr) language support** ([#179](https://github.com/speedyk-005/yasbd-lib/pull/179)).
 - **Kazakh (kk) language support** ([#171](https://github.com/speedyk-005/yasbd-lib/pull/171)).
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 
 ## 🌐 Supported Languages ([API](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbdrules))
 
-35 languages supported.
+36 languages supported.
 
 <details>
 <summary>Click to see all supported languages</summary>
@@ -129,6 +129,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 | 🇸🇪 | sv   | Swedish |
 | 🇹🇿 | sw   | Swahili |
 | 🇹🇭 | th   | Thai |
+| 🇹🇷 | tr   | Turkish |
 | 🇺🇦 | uk   | Ukrainian |
 | 🇵🇰 | ur   | Urdu |
 | 🇻🇳 | vi   | Vietnamese |

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -134,7 +134,7 @@ class Rules:
         # Notes & postscript markers
         "n.b", "p.s", "p.p.s", "sci", "scill", "s.vloc",
 
-        # Streets
+        # Address elements
         "ave", "blv", "blvd", "ct", "jct", "ln", "pen", "pl",
         "rd", "riv", "rt", "rte", "sq", "st", "wy",
 

--- a/src/yasbd/rules/tr.py
+++ b/src/yasbd/rules/tr.py
@@ -1,0 +1,88 @@
+from yasbd.rules.base import Rules
+
+
+# fmt: off
+class TrRules(Rules):
+
+
+    TITLE_ABBRVS = Rules.TITLE_ABBRVS | {
+        # Social & Address
+        "sn", "han", "hz",
+
+        # Standard Professional / Academic (Shared & Native)
+        "av", "bşk", "uzm", "md", "müh", "mim", "ecz",
+        "doç", "ord", "yrd", "gör", "arş",
+
+        # Military Ranks & Administration
+        "alb", "bnb", "tğm", "ütğm", "atğm", "yzb", "yarb",
+        "korg", "tümg", "tuğg", "org", "bçvş", "çvş", "üçvş",
+        "onb", "astsb", "asb", "sb", "gnkur", "kur",
+    }
+
+    DOTTED_GEOPOL_ABBRVS = Rules.DOTTED_GEOPOL_ABBRVS | {
+        "T.C", "A.B.D", "K.K.T.C", "İng", "Alm", "Fr", "Rus",
+    }
+
+    REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
+        "s", "ss", "c",  "yay", "yy", "doğ", "vb", "v.b",
+        "sf", "mad", "par", "böl", "bzk", "md", "sy",
+    }
+
+    INLINE_ONLY_ABBRVS = Rules.INLINE_ONLY_ABBRVS | {
+        # Bibliographical & reference abbreviations
+        "vb", "bnz", "ör", "drl", "dzl", "bk", "bkz",
+        "bknz", "çev", "haz",
+
+        # Academic & subject abbreviations
+        "huk", "ekon", "jeol", "ped",
+
+        # Address elements
+        "mah", "cad", "sok", "sk", "bul", "blv",
+        "apt", "il", "ilç", "şti",
+    }
+
+    SECTION_MARKERS = Rules.SECTION_MARKERS | {
+        "Bölüm", "Kısım", "Madde", "Fıkra", "Bent",
+        "Paragraf", "Tablo", "Şekil", "Giriş", "Sonuç",
+        "Özet", "Önsöz", "Ek", "Kaynakça", "Kaynaklar",
+    }
+
+    DATE_ABBRVS = Rules.DATE_ABBRVS | {
+        # Months
+        "oca", "şub", "mar", "nis", "may", "haz", "tem", "ağu",
+        "eyl", "eki", "kas", "ara",
+
+        # Days
+        "pzt", "sal", "çar", "per", "cum", "cmt", "paz",
+    }
+
+    NAMES_WITH_EXCLAMATION = Rules.NAMES_WITH_EXCLAMATION | {
+        # Banking & Telecommunications
+        "Akbank", "Garanti", "Vodafone", "Turkcell", "Türk Telekom",
+
+        # E-commerce, Delivery & Retail
+        "Yemeksepeti", "Trendyol", "Hepsiburada", "Getir", "n11",
+        "Migros", "A101", "BİM", "ŞOK", "CarrefourSA",
+
+        # Shopping, Fashion & Lifestyle
+        "ÇiçekSepeti", "LC Waikiki", "Gratis", "Watsons",
+        "MediaMarkt", "Teknosa", "Koçtaş", "Mavi", "Penti",
+    }
+
+    COMMON_SENT_STARTERS = {
+        # Pronouns
+        "Ben", "Sen", "O", "Biz", "Siz", "Onlar", "Bu",
+        "Şu", "Bunlar", "Şunlar",
+
+        # Question Words
+        "Hangi", "Kim", "Nasıl", "Ne", "Neden", "Nerede",
+        "Niçin",
+
+        # Conjunctions & Transitions
+        "Ama", "Ancak", "Ayrıca", "Bundan", "Dolayısıyla",
+        "Fakat", "Halbuki", "İlk", "Lakin", "Mesela", "Oysa",
+        "Sonra", "Sonuçta", "Yani", "Zaten", "Çünkü",
+        "Öncelikle", "Örneğin", "Üstelik",
+    }
+
+# fmt: on

--- a/tests/test_data/turkish.py
+++ b/tests/test_data/turkish.py
@@ -1,0 +1,42 @@
+ISO_CODE = "tr"
+TEST_DATA = [
+    # Basic punctuation
+    "Merhaba dünya!| Nasılsın?| İyiyim, teşekkür ederim.",
+    "Adın ne?| Benim adım Ayşe.",
+    "İşte!| Onu buldum.",
+
+    # Abbreviations
+    "Prof. Yılmaz ders verdi.",
+    "Prof. Dr. Demir konferansta konuştu.",
+    "Dr. Kaya hastaları kabul etti.",
+    "Doç. Çelik seminer düzenledi.",
+    "Arş. Gör. Aksoy araştırmayı yürütüyor.",
+    "Av. Aydın davayı kazandı.",
+    "Müh. Yıldız projeyi tamamladı.",
+    "Bk. Bölüm 3 ve s. 15.",
+    "2024'te 15 Oca. tarihinde Ankara'da konferans düzenlendi.",
+    "Mad. 5 ve fıkra 2 uygulanacaktır.",
+    "Kitap, dergi vb. kaynaklardan yararlanıldı.",
+    "Belgeler, raporlar, vs. dosyada saklanıyor.",
+    "Bkz. Ek A ve Tablo 2.",
+    "Bk. s. 120-125.",
+
+    # Structural headings
+    "Bölüm 1. Giriş.| Oda sessiz ve karanlıktı.",
+    "Kısım 2. Literatür Taraması.| Proje birçok dili destekliyor.",
+    "Ek A. Ek Belgeler.| Tablolar aşağıda verilmiştir.",
+
+    # Parentheses and quotes
+    "O (Ders geçen hafta başladı.) üniversitede okuyor.",
+    "Profesör: «Bu önemli.»| Öğrenciler dikkatle dinliyordu.",
+    "Yazar ‹Bu bölüm önemlidir.› dedi.| Kitap yayımlandı.",
+    "(Bk. Tablo 3. Bu bellek düzenidir.)| Sistem normal çalışmaya devam etti.",
+    "Profesör «Bu doğru.» dedi.| Kimse itiraz etmedi.",
+    'Öğretmen: "Sessiz olun."| Öğrenciler dinledi.',
+    "«Ders başladı.» diye duyurdu.| Herkes yerine oturdu.",
+
+    # Ellipsis
+    "Bir süre düşündü... ama hiçbir şey söylemedi.",
+    "Her şey hazırdı... fakat elektrik kesildi.",
+    "Hava çok güzel!| Kuşlar ötüyor...| Dışarı çıkmak için harika bir gün.",
+]


### PR DESCRIPTION
Part of #20 and #132.

## Summary

Add Turkish (tr) as a built-in language. Turkic family, Latin script, inherits from `Rules`. 36 languages now.

## What Changed

- New `tr.py` rule file with Turkish-specific title, geopolitical, reference, date, and inline abbreviation sets
- New `turkish.py` test data with real-world sentences covering punctuation, abbreviations, headings, quotes, and ellipsis
- Updated base.py address comment
- README language count bumped to 36, table row added
- CHANGELOG updated

## Testing

- `pytest tests/test_boundary_detector.py -k "tr-"` passes
- Full suite green, no regressions