### PR TITLE
Add Romanian language support and extend base references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Brand/snack exclamation entries**: Crunch and Banga added to `NAMES_WITH_EXCLAMATION`.
+- **Extended `REFERENCE_ABBRVS`** ([#189](https://github.com/speedyk-005/yasbd-lib/pull/189)): added `cit` and `nr` for cross-language use.
 - **Set literal reformatting script** ([#165](https://github.com/speedyk-005/yasbd-lib/pull/165)): `scripts/reformat_sets.py` automatically balances set items to ≤70 chars per line.
 - **Lithuanian (lt) language support** ([#168](https://github.com/speedyk-005/yasbd-lib/pull/168)).
 - **Turkish (tr) language support** ([#180](https://github.com/speedyk-005/yasbd-lib/pull/180)).
 - **Bulgarian (bg) language support** ([#185](https://github.com/speedyk-005/yasbd-lib/pull/185)).
 - **Kazakh (kk) language support** ([#171](https://github.com/speedyk-005/yasbd-lib/pull/171)).
+- **Romanian (ro) language support** ([#189](https://github.com/speedyk-005/yasbd-lib/pull/189)).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 
 ## 🌐 Supported Languages ([API](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbdrules))
 
-37 languages supported.
+38 languages supported.
 
 <details>
 <summary>Click to see all supported languages</summary>
@@ -125,6 +125,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 | 🇳🇱 | nl   | Dutch |
 | 🇵🇱 | pl   | Polish |
 | 🇵🇹 | pt   | Portuguese |
+| 🇷🇴 | ro   | Romanian |
 | 🇷🇺 | ru   | Russian |
 | 🇸🇰 | sk   | Slovak |
 | 🇸🇪 | sv   | Swedish |

--- a/src/yasbd/rules/README.md
+++ b/src/yasbd/rules/README.md
@@ -29,6 +29,7 @@
 | `nl.py` | Dutch | West Germanic |
 | `pl.py` | Polish | West Slavic |
 | `pt.py` | Portuguese | Romance |
+| `ro.py` | Romanian | Romance |
 | `ru.py` | Russian | East Slavic / Cyrillic |
 | `sk.py` | Slovak | West Slavic |
 | `sv.py` | Swedish | North Germanic |

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -88,12 +88,12 @@ class Rules:
         "tbls", "v", "vol", "vols",
 
         # Section / Structure
-        "ann", "art", "arts", "cap", "cl", "cls", "col",
+        "ann", "art", "arts", "cap", "cl", "cls", "col", "cit",
         "cols", "para", "paras", "quaest", "sec", "sect",
         "secs", "subsec",
 
         # Legal / Numbering / Cross References
-        "a.c", "a.d", "a.u.c", "b.c", "lc", "n", "nn",
+        "a.c", "a.d", "a.u.c", "b.c", "lc", "n", "nn", "nr",
         "no", "nos", "n°", "n.º", "qv", "reg", "regs",
 
         # Scientific / Technical

--- a/src/yasbd/rules/ro.py
+++ b/src/yasbd/rules/ro.py
@@ -1,0 +1,66 @@
+from yasbd.rules.base import Rules
+
+
+# fmt: off
+class RoRules(Rules):
+
+
+    TITLE_ABBRVS = Rules.TITLE_ABBRVS | {
+        # Standard Professional / Academic
+        "arh", "av", "conf", "lect", "asist", "acad",
+        "cerc", "dir", "drd", "prep",
+
+        # Social & Religious Address
+        "sf", "cuv", "părinte",
+
+        # Traditional Given Name Initials (Highly critical)
+        "Al", "Dem", "Fr", "Gh", "Gr", "Șt",
+    }
+
+    DOTTED_GEOPOL_ABBRVS = Rules.DOTTED_GEOPOL_ABBRVS | {
+        "R.S.R", "R.P.R", "S.U.A", "U.E", "M.B",
+    }
+
+    REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
+        # Bibliographical & Academic Citations
+        "vezi", "apud", "id", "trad", "coord", "colab",
+        "urm", "ș.a", "obs", "șamd",
+
+        # Legal & Structural Cross-References
+        "alin", "lit", "pct", "secț",
+    }
+
+    SECTION_MARKERS = Rules.SECTION_MARKERS | {
+        "Capitolul", "Secțiunea", "Articolul", "Alineatul", "Tabelul",
+        "Figura", "Anexa", "Nota", "Introducere", "Concluzii",
+    }
+
+    # Administrative, Geographic, & Address Elements
+    INLINE_ONLY_ABBRVS = Rules.INLINE_ONLY_ABBRVS | {
+        "str", "bd", "bld", "os", "al", "p-ța", "intr", "jud", "loc",
+        "com", "sat", "sc", "et", "ap",
+    }
+
+    DATE_ABBRVS = Rules.DATE_ABBRVS | {
+        "ian", "iun", "iul", "mar", "mie", "joi", "vin",
+        "sâm", "dum",
+    }
+
+    COMMON_SENT_STARTERS = {
+        # Pronouns
+        "Eu", "Tu", "El", "Ea", "Noi", "Voi", "Ei", "Ele",
+        "Acest", "Această", "Acestea", "Aceștia",
+        "Cine", "Ce", "Care", "Nimeni", "Cineva",
+
+        # Question words
+        "Unde", "Cum", "Când", "De ce",
+
+        # Common Transitions / Adverbs
+        "Deși", "Deoarece", "Pentru că", "Fiindcă",
+        "Dacă", "Prin urmare", "Deci", "În plus",
+        "Mai mult", "Totuși", "De pildă", "De exemplu",
+        "În primul rând", "În concluzie", "Astfel",
+        "Astăzi", "Ieri",
+    }
+
+# fmt: on

--- a/tests/test_data/romanian.py
+++ b/tests/test_data/romanian.py
@@ -1,0 +1,30 @@
+ISO_CODE = "ro"
+TEST_DATA = [
+    # Basic punctuation
+    "Bună ziua.| Ce mai faceți?",
+    "Ce oră este?| Este târziu.",
+    "Minunat!| Să mergem.",
+
+    # Abbreviations
+    "Prof. Marinescu și dr Radu colaborează.| Cercetarea continuă.",
+    "Ing. Andrei lucrează la proiect.| Arh. Miron l-a aprobat.",
+    "Sf. Petru este hramul bisericii.| Slujba începe la ora 10.",
+    "Al. Vlahuță a scris poezii.| Gr. Alexandrescu a răspuns.",
+    "Vezi art. 15 din lege.| Alineatul următor explică sancțiunile.",
+    "Conf. pct. 3, termenul expiră.| Trebuie reînnoit.",
+    "Citiți cap. 3 și 4.| Examenul este săptămâna viitoare.",
+    "Str. Mihai Viteazul nr. 15.| Clădirea este la colț.",
+    "Bd. Unirii nr. 25, ap. 8.| Scara B, etajul 3.",
+    "Aduceți apă, pâine, etc.| Lista e lungă.",
+    "Discutăm despre termeni, șamd.| Nu e necesar să insistăm.",
+    "A venit, a văzut, dpdv al strategiei.| Rezultatul e clar.",
+
+    # Parentheses and quotes
+    "El a spus: \"Vin mâine.\"| Apoi a plecat.",
+    "„Ce faci?” a întrebat ea.| „Studiez.”",
+    "Programul (vezi anexa) este finalizat.| Urmează evaluarea.",
+
+    # Ellipsis
+    "A intrat... a privit în jur... și a plecat.",
+    "Secvența continuă...| Mai târziu s-a lămurit totul.",
+]


### PR DESCRIPTION
Part of #20 and #132.

## Summary

Add Romanian (ro) as a built-in language. Romance family, Latin script, inherits from `Rules`. 38 languages now.

## What Changed

- New `ro.py` rule file with Romanian-specific title, reference, inline, and date abbreviation sets
- New `romanian.py` test data with real-world sentences covering punctuation, abbreviations, addresses, quotes, and ellipsis
- Added `cit` and `nr` to base `REFERENCE_ABBRVS`
- README language count bumped to 38, table and rules README rows added

## Testing

- `pytest tests/test_boundary_detector.py -k "ro-"` passes
- Full suite green, no regressions

## Risk/Rollout

Low. Romanian extends `Rules` without touching any other language. Base additions (`cit`, `nr`) are safe cross-language.
