### PR TITLE
Simplify pysbd_component.TextSpan.__eq__ attribute checks

### DIFF
--- a/src/yasbd/utils/pysbd_adapter.py
+++ b/src/yasbd/utils/pysbd_adapter.py
@@ -24,8 +24,8 @@ class TextSpan:
         return f"[{self.start}:{self.end}] {self.sent}"
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, TextSpan) or (
-            hasattr(other, "sent") and hasattr(other, "start") and hasattr(other, "end")
+        if isinstance(other, TextSpan) or all(
+            hasattr(other, attr) for attr in ("sent", "start", "end")
         ):
             return (self.start, self.end, self.sent) == (
                 other.start,


### PR DESCRIPTION
Closes #191

## Summary
Simplifies the `__eq__` method in `TextSpan` class by replacing multiple `hasattr()` calls joined with `and` with a single `all()` call.

## Changes
- `src/yasbd/utils/pysbd_adapter.py`: Refactor `TextSpan.__eq__` to use `all(hasattr(other, attr) for attr in ("sent", "start", "end"))` instead of `hasattr(other, "sent") and hasattr(other, "start") and hasattr(other, "end")`

## Benefits
- Improves readability
- Avoids repeating `hasattr(...)`
- Makes adding or removing required attributes a one-line change
- Keeps the same short-circuit behavior and semantics

## Testing
- All existing tests pass (67 passed, 2 skipped)
- Verified equality behavior with TextSpan objects, duck-typed objects, and objects without required attributes

This is purely a readability refactor with no intended behavioral changes.