### PR TITLE
Code quality cleanup across rule files and internal methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Code quality cleanup** ([#203](https://github.com/speedyk-005/yasbd-lib/pull/203)):
+  - Extracted `_apply_cleaning_pipeline` from `StreamCleaner.__next__` and renamed `CLEANING_PIPELINE` to `DEFAULT_CLEANING_PIPELINE`.
+  - Simplified `detect()` offset calculation by removing unnecessary ternary.
+  - Simplified `TextSpan.__eq__` with `all()` for cleaner `hasattr` checks.
+  - Fixed double spaces after commas (nl, my, sv, tr, id) and double space after operator (bg).
+- **Merged "Pronouns & Demonstratives" header into "Pronouns"** ([#196](https://github.com/speedyk-005/yasbd-lib/pull/196)): comment-only change in id.py and vi.py.
+
 ### Removed
 
 - **Unused timeout parameter from `_create_external_cleaner`** ([#193](https://github.com/speedyk-005/yasbd-lib/pull/193)).

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -185,7 +185,7 @@ class BoundaryDetector:
             boundaries = rule.apply(para.rstrip(), self.preserve_quote_and_paren)
 
             for pos in boundaries[1:]:
-                yield offset + pos if not relative else pos
+                yield offset + pos
 
             if not relative:
                 offset += len(para)

--- a/src/yasbd/rules/bg.py
+++ b/src/yasbd/rules/bg.py
@@ -45,7 +45,7 @@ class BgRules(RuRules):
         "пон", "вто", "сря", "чет", "пет", "съб", "нед",
     }
 
-    COMMON_SENT_STARTERS =  {
+    COMMON_SENT_STARTERS = {
         # Pronouns
         "Аз", "Ти", "Той", "Тя", "То", "Ние", "Вие", "Те",
         "Това", "Тези", "Тази", "Този",

--- a/src/yasbd/rules/id.py
+++ b/src/yasbd/rules/id.py
@@ -34,7 +34,7 @@ class IdRules(Rules):
 
     SECTION_MARKERS = Rules.SECTION_MARKERS | {
         "Bab", "Pasal", "Ayat", "Bagian", "Subbagian",
-        "Lampiran",  "Paragraf", "Sub-bab",
+        "Lampiran", "Paragraf", "Sub-bab",
     }
 
     INLINE_ONLY_ABBRVS = Rules.INLINE_ONLY_ABBRVS | {

--- a/src/yasbd/rules/my.py
+++ b/src/yasbd/rules/my.py
@@ -56,7 +56,7 @@ class MyRules(Rules):
     }
 
     POST_QUOTATIVE_PARTICLES = {
-        "ဟု",  "လို့",  "ဟူ၍",
+        "ဟု", "လို့", "ဟူ၍",
     }
 
     DISCOURSE_FINAL_PARTICLES = {

--- a/src/yasbd/rules/nl.py
+++ b/src/yasbd/rules/nl.py
@@ -27,7 +27,7 @@ class NlRules(DeRules):
 
     REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
         # Bibliographical, Page, and Document References
-        "art", "afb", "hfdst", "blz", "nr",  "par", "reg",
+        "art", "afb", "hfdst", "blz", "nr", "par", "reg",
         "bijl", "ca", "cf", "ed", "vert", "id",
 
         # Legal, Corporate, and Formal Citation Markers

--- a/src/yasbd/rules/sv.py
+++ b/src/yasbd/rules/sv.py
@@ -17,7 +17,7 @@ class SvRules(DeRules):
 
     REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
         "s", "sid", "anm", "ang", "bil", "kap", "forts",
-        "förf", "avd", "uppl", "utg", "red",  "hft",
+        "förf", "avd", "uppl", "utg", "red", "hft",
         "sammanst", "m.fl", "o.l", "osv", "o.s.v", "kl",
     }
 

--- a/src/yasbd/rules/tr.py
+++ b/src/yasbd/rules/tr.py
@@ -24,7 +24,7 @@ class TrRules(Rules):
     }
 
     REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
-        "s", "ss", "c",  "yay", "yy", "doğ", "vb", "v.b",
+        "s", "ss", "c", "yay", "yy", "doğ", "vb", "v.b",
         "sf", "mad", "par", "böl", "bzk", "md", "sy",
     }
 

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -100,7 +100,7 @@ def _clean_ocr_text(text: str) -> str:
     return PAGE_FINDER.sub("", cleaned_text)
 
 
-CLEANING_PIPELINE = {
+DEFAULT_CLEANING_PIPELINE = {
     "fix_mojibake": ftfy.fix_text,
     "fix_ocr_text": _clean_ocr_text,
     "unwrap_htmls": lambda t: t if "<" not in t else HTML_TAGS_FINDER.sub("", t),
@@ -177,10 +177,10 @@ class StreamCleaner(StreamCleanerStub):
         self.steps_to_skip = set(steps_to_skip or ())
         self.verbose = verbose
 
-        if invalid_steps := self.steps_to_skip - set(CLEANING_PIPELINE):
+        if invalid_steps := self.steps_to_skip - set(DEFAULT_CLEANING_PIPELINE):
             raise InvalidInputError(
                 f"🧩 Oops! Unknown step(s): {', '.join(repr(s) for s in sorted(invalid_steps))}. "
-                f"Valid steps: {', '.join(CLEANING_PIPELINE.keys())}."
+                f"Valid steps: {', '.join(DEFAULT_CLEANING_PIPELINE.keys())}."
             )
 
         self.extra_steps = list(extra_steps or ())
@@ -198,32 +198,31 @@ class StreamCleaner(StreamCleanerStub):
             stripped = para.strip()
             if not stripped:
                 continue
-
-            cleaned_text = stripped
-            for step_name in CLEANING_PIPELINE:
-                if step_name not in self.steps_to_skip:
-                    log_info(self.verbose, "Applying step: {}", step_name)
-                    cleaned_text = CLEANING_PIPELINE[step_name](cleaned_text)
-
-            for step in self.extra_steps:
-                log_info(
-                    self.verbose, "Applying extra step: {}", getattr(step, "__name__", step)
-                )
-
-                try:
-                    result = step(cleaned_text)
-                except Exception as e:
-                    raise CleanStepError(
-                        f"extra step {getattr(step, '__name__', step)!r} raised an error.\n"
-                        f"Details: {e!s}"
-                    ) from e
-
-                if not isinstance(result, str):
-                    raise CleanStepError(
-                        f"extra step {getattr(step, '__name__', step)!r} "
-                        f"returned {type(result).__name__}, expected str"
-                    )
-                cleaned_text = result
-            return cleaned_text
+            return self._apply_cleaning_pipeline(stripped)
 
         raise StopIteration
+
+    def _apply_cleaning_pipeline(self, text: str) -> str:
+        for step_name in DEFAULT_CLEANING_PIPELINE:
+            if step_name not in self.steps_to_skip:
+                log_info(self.verbose, "Applying step: {}", step_name)
+                text = DEFAULT_CLEANING_PIPELINE[step_name](text)
+
+        for step in self.extra_steps:
+            log_info(self.verbose, "Applying extra step: {}", getattr(step, "__name__", step))
+
+            try:
+                result = step(text)
+            except Exception as e:
+                raise CleanStepError(
+                    f"extra step {getattr(step, '__name__', step)!r} raised an error.\n"
+                    f"Details: {e!s}"
+                ) from e
+
+            if not isinstance(result, str):
+                raise CleanStepError(
+                    f"extra step {getattr(step, '__name__', step)!r} "
+                    f"returned {type(result).__name__}, expected str"
+                )
+            text = result
+        return text

--- a/src/yasbd/utils/pysbd_adapter.py
+++ b/src/yasbd/utils/pysbd_adapter.py
@@ -24,14 +24,10 @@ class TextSpan:
         return f"[{self.start}:{self.end}] {self.sent}"
 
     def __eq__(self, other) -> bool:
-        if isinstance(other, TextSpan) or (
-            hasattr(other, "sent") and hasattr(other, "start") and hasattr(other, "end")
+        if isinstance(other, TextSpan) or all(
+            hasattr(other, attr) for attr in ("sent", "start", "end")
         ):
-            return (self.start, self.end, self.sent) == (
-                other.start,
-                other.end,
-                other.sent,
-            )
+            return (self.start, self.end, self.sent) == (other.start, other.end, other.sent)
         return NotImplemented
 
     def __hash__(self) -> int:


### PR DESCRIPTION
## Objective

Clean up code quality issues flagged by CodeFactor and simplify internal logic across the codebase.

## Changes

- Replaced repeated `hasattr(..., ...)` with `all(hasattr(other, attr) for attr in (...))` in TextSpan.__eq__ in pysbd_adapter
- Removed unnecessary ternary in `detect()` — `offset + pos` works for both relative and absolute modes since offset stays 0 in relative mode
- Extracted `_apply_cleaning_pipeline()` method from `StreamCleaner.__next__()` and renamed `CLEANING_PIPELINE` to `DEFAULT_CLEANING_PIPELINE`
- Fixed multiple CodeFinder warnings: double spaces after commas in nl.py, my.py, sv.py, tr.py, id.py and double space after operator in bg.py

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format && ruff check --fix` on the modified files.
- [ ] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #191
