### PR TITLE
Prevent double boundary for .\n in detect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Double boundary for `.\n`** ([#205](https://github.com/speedyk-005/yasbd-lib/issues/205)): `detect()` yielded two consecutive offsets for `.\n`, leaving an empty span when sentences were reconstructed. Added `\n` to the negative lookahead in `CANDIDATE_BOUNDARY_FINDER` so the terminator no longer creates a separate boundary when a newline follows.
+- **Double boundary for `.\n`** ([#207](https://github.com/speedyk-005/yasbd-lib/pull/207)): `detect()` yielded two consecutive offsets for `.\n`, leaving an empty span when sentences were reconstructed. Added `\n` to the negative lookahead in `CANDIDATE_BOUNDARY_FINDER` so the terminator no longer creates a separate boundary when a newline follows.
 - **Vertical list detection for multi-digit numbers** ([#204](https://github.com/speedyk-005/yasbd-lib/pull/204)): Expanded VERTICAL_LIST_START_FINDER quantifier to `{1,4}` and added `re.M` flag so multi-digit list markers at any line start are not mistaken for sentence boundaries.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Double boundary for `.\n`** ([#205](https://github.com/speedyk-005/yasbd-lib/issues/205)): `detect()` yielded two consecutive offsets for `.\n` (one at `.` and another at `\n`), leaving an empty span when sentences were reconstructed from offsets. Added `\n` to the negative lookahead at the end of `CANDIDATE_BOUNDARY_FINDER` so the terminator no longer creates a separate boundary when a newline follows. Newline-bound sentence splits still work via the `(?<=\n)(?!\n)` alternative.
+- **Double boundary for `.\n`** ([#205](https://github.com/speedyk-005/yasbd-lib/issues/205)): `detect()` yielded two consecutive offsets for `.\n`, leaving an empty span when sentences were reconstructed. Added `\n` to the negative lookahead in `CANDIDATE_BOUNDARY_FINDER` so the terminator no longer creates a separate boundary when a newline follows.
 - **Vertical list detection for multi-digit numbers** ([#204](https://github.com/speedyk-005/yasbd-lib/pull/204)): Expanded VERTICAL_LIST_START_FINDER quantifier to `{1,4}` and added `re.M` flag so multi-digit list markers at any line start are not mistaken for sentence boundaries.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Double boundary for `.\n`** ([#205](https://github.com/speedyk-005/yasbd-lib/issues/205)): `detect()` yielded two consecutive offsets for `.\n` (one at `.` and another at `\n`), leaving an empty span when sentences were reconstructed from offsets. Added `\n` to the negative lookahead at the end of `CANDIDATE_BOUNDARY_FINDER` so the terminator no longer creates a separate boundary when a newline follows. Newline-bound sentence splits still work via the `(?<=\n)(?!\n)` alternative.
 - **Vertical list detection for multi-digit numbers** ([#204](https://github.com/speedyk-005/yasbd-lib/pull/204)): Expanded VERTICAL_LIST_START_FINDER quantifier to `{1,4}` and added `re.M` flag so multi-digit list markers at any line start are not mistaken for sentence boundaries.
 
 ### Removed

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@k-anushka14](https://github.com/k-anushka14)** | Removed unused timeout parameter from external cleaner; merged Pronouns & Demonstratives header into Pronouns |
 | **[@kernelpanic888](https://github.com/kernelpanic888)** | Non-German ordinal boundary inheritance fix |
 | **[@Mayankshrey438](https://github.com/Mayankshrey438)** | Armenian language support & flattened list heuristic |
+| **[@MasRama](https://github.com/MasRama)** | Double boundary for `.\n` fix |
 | **[@Rajesh270712](https://github.com/Rajesh270712)** | Base + English rule contributions |
 | **[@sanmaxdev](https://github.com/sanmaxdev)** | Language tag normalization helper |
 | **[@terminalchai](https://github.com/terminalchai)** | Burmese and Thai reporting words fix |

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -274,7 +274,7 @@ class Rules:
             )
 
             # Not followed by another terminators (clusters)
-            (?!\s*+{cls.TERMINATORS_PATTERN})
+            (?!\n|\s*+{cls.TERMINATORS_PATTERN})
             """, re2.X,
         )
 

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -116,19 +116,6 @@ def test_detect_paragraph_eof_sentinel(en_detector):
     assert result == [6, 15]
 
 
-def test_detect_dot_newline_no_double_boundary(en_detector):
-    """test that `.\n` produces a single boundary, not one at `.` and another at `\n`.
-
-    Regression test for the double-boundary bug where `detect()` yielded two
-    consecutive offsets for `.\n`, leaving an empty span when sentences were
-    reconstructed from offsets.
-    """
-    result = list(en_detector.detect("Hello world.\nNext sentence.", relative=False))
-    assert result == [13, 27]
-    assert all(isinstance(b, int) for b in result)
-    assert result == sorted(result)
-
-
 def test_rule_cache_lru(en_detector):
     """test that rule objects are cached (max 5) and reused on lang switch."""
     # Same lang = same cached object
@@ -160,32 +147,43 @@ def test_rule_cache_lru(en_detector):
         "Each tick denotes an increase of 100 meV.| Each data point follows.",
         "The supply reached 10 kV.| Measurements continued.",
         "The frequency was 20 MHz.| The receiver locked.",
+
         # Day-month ambiguity (fix for #29)
         "The meeting is at 9 a.m. Monday.",
         "The event starts at 11a.m. Tue.",
         "The store opens at 8 p.m. December.",
         "The meeting is at 2 p.m.| Martin called.",
         "The meeting is at 10 a.m.| Monday's agenda was postponed.",
+
         # "&" separator (fix for #150)
         "Trying to get back to Com. & Adm. through the most direct path in the dark.",
+
         # Not a list (fix for #52)
         "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
         "You are going to the store, and so am I.| We can go together.",
+
         # Bracketed references (fix for #34)
         "Yan et al. [2004] analysed SSH variations.| The study was comprehensive.",
         "Fig. [1] shows the architecture.| Figure 2 provides details.",
         "As shown in pp. [55-60], the results are significant.| This confirms our hypothesis.",
         "See sec. [2.1] for details.| The methodology is described there.",
+
         # Newlines (fix for #50)
         "The simplest way\nto get started is with pip.",
         "10 languages supported today\n|Target is 22+.",
         "> Somewhere, something incredible\n> is waiting to be known",
+
+        # Dot followed by newline (fix for #205)
+        "Hello world.\n|Next sentence.",
+
         # Emojis (fix for #73)
         "Nice work! 👍| Next step.",
         "The alternative is to put it before the full stop 👉.| So cool, right?",
+
         # Coordinate directions ambiguity (fix for #134)
         "Server A at 40.7128° N, 74.0060° W.| Server B at 34.0522° S, 118.2437° E.",
         "N. Scott Momaday is a writer.| He won the Pulitzer.",
+
         # Multi-digit vertical list items
         "12. The first item.\n|13. The second item.",
         "    A12. The first item.\n|    B13. The second item.",

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -116,6 +116,19 @@ def test_detect_paragraph_eof_sentinel(en_detector):
     assert result == [6, 15]
 
 
+def test_detect_dot_newline_no_double_boundary(en_detector):
+    """test that `.\n` produces a single boundary, not one at `.` and another at `\n`.
+
+    Regression test for the double-boundary bug where `detect()` yielded two
+    consecutive offsets for `.\n`, leaving an empty span when sentences were
+    reconstructed from offsets.
+    """
+    result = list(en_detector.detect("Hello world.\nNext sentence.", relative=False))
+    assert result == [13, 27]
+    assert all(isinstance(b, int) for b in result)
+    assert result == sorted(result)
+
+
 def test_rule_cache_lru(en_detector):
     """test that rule objects are cached (max 5) and reused on lang switch."""
     # Same lang = same cached object
@@ -147,40 +160,32 @@ def test_rule_cache_lru(en_detector):
         "Each tick denotes an increase of 100 meV.| Each data point follows.",
         "The supply reached 10 kV.| Measurements continued.",
         "The frequency was 20 MHz.| The receiver locked.",
-
         # Day-month ambiguity (fix for #29)
         "The meeting is at 9 a.m. Monday.",
         "The event starts at 11a.m. Tue.",
         "The store opens at 8 p.m. December.",
         "The meeting is at 2 p.m.| Martin called.",
         "The meeting is at 10 a.m.| Monday's agenda was postponed.",
-
         # "&" separator (fix for #150)
         "Trying to get back to Com. & Adm. through the most direct path in the dark.",
-
         # Not a list (fix for #52)
         "I really want letter A.| I know that I asked you for the B.| I changed my mind.",
         "You are going to the store, and so am I.| We can go together.",
-
         # Bracketed references (fix for #34)
         "Yan et al. [2004] analysed SSH variations.| The study was comprehensive.",
         "Fig. [1] shows the architecture.| Figure 2 provides details.",
         "As shown in pp. [55-60], the results are significant.| This confirms our hypothesis.",
         "See sec. [2.1] for details.| The methodology is described there.",
-
         # Newlines (fix for #50)
         "The simplest way\nto get started is with pip.",
         "10 languages supported today\n|Target is 22+.",
         "> Somewhere, something incredible\n> is waiting to be known",
-
         # Emojis (fix for #73)
         "Nice work! 👍| Next step.",
         "The alternative is to put it before the full stop 👉.| So cool, right?",
-
         # Coordinate directions ambiguity (fix for #134)
         "Server A at 40.7128° N, 74.0060° W.| Server B at 34.0522° S, 118.2437° E.",
         "N. Scott Momaday is a writer.| He won the Pulitzer.",
-
         # Multi-digit vertical list items
         "12. The first item.\n|13. The second item.",
         "    A12. The first item.\n|    B13. The second item.",


### PR DESCRIPTION
## Objective

`detect()` yielded two consecutive boundary offsets for `.\n`, one at the `.` and another at the `\n` which leaves an empty span when sentences were reconstructed from offsets. PySBD treats `.\n` as a single boundary.

## Changes

- Added `\n` to the negative lookahead at the end of `CANDIDATE_BOUNDARY_FINDER` in `src/yasbd/rules/base.py` (`(?!\n|\s*+{cls.TERMINATORS_PATTERN})`), so the terminator no longer creates a separate boundary when a newline follows.
- The `(?<=\n)(?!\n)` alternative is untouched, so newline-bound sentence splits still work.
- Added a regression test `test_detect_dot_newline_no_double_boundary` in `tests/test_boundary_detector.py`.
- Added a CHANGELOG entry under `### Fixed`.

### Types of change

- [x] Bug fix (non-breaking change fixing an issue)

## Verification

- [x] I ran `pytest` and all tests pass (102 passed, 2 skipped, 1025 subtests passed).
- [ ] I ran `ruff format && ruff check --fix` on the modified files.
- [x] I have added tests for my changes.
- [x] My changes don't require documentation updates.

## Related Issues

- Fixes #205