### PR TITLE
Document that built-in language set is frozen for v1.x

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -15,6 +15,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@JosephM961](https://github.com/JosephM961)** | Documentation additions and typo fixes |
 | **[@k-anushka14](https://github.com/k-anushka14)** | Removed unused timeout parameter from external cleaner; merged Pronouns & Demonstratives header into Pronouns |
 | **[@kernelpanic888](https://github.com/kernelpanic888)** | Non-German ordinal boundary inheritance fix |
+| **[@MohammedAnasNathani](https://github.com/MohammedAnasNathani)** | Documentation for built-in language freeze |
 | **[@Mayankshrey438](https://github.com/Mayankshrey438)** | Armenian language support & flattened list heuristic |
 | **[@MasRama](https://github.com/MasRama)** | Double boundary for `.\n` fix |
 | **[@Rajesh270712](https://github.com/Rajesh270712)** | Base + English rule contributions |

--- a/README.md
+++ b/README.md
@@ -92,9 +92,10 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 
 39 languages supported.
 
+> [!NOTE]
 > **v1.x freeze:** The built-in language set is locked for the v1.x series (reached with Armenian; see #132 / #198).
-> New languages are **not** accepted as built-in modules — ship them as external
-> [lang packs](#-lang-packs) via `register_lang_packs()` instead. Focus for core
+> New languages are **not** accepted as built-in modules. They should be distributed as external packs.
+> Use [lang packs](#-lang-packs) via `register_lang_packs()` instead. Focus for core
 > stays on bug fixes, edge cases, and API stabilization. Non-breaking improvements
 > to *existing* language rules are still welcome.
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 
 39 languages supported.
 
+> **v1.x freeze:** The built-in language set is locked for the v1.x series (reached with Armenian; see #132 / #198).
+> New languages are **not** accepted as built-in modules — ship them as external
+> [lang packs](#-lang-packs) via `register_lang_packs()` instead. Focus for core
+> stays on bug fixes, edge cases, and API stabilization. Non-breaking improvements
+> to *existing* language rules are still welcome.
+
 <details>
 <summary>Click to see all supported languages</summary>
 


### PR DESCRIPTION
## Summary
Part #198.

Adds a short note under **Supported Languages** that the built-in set is frozen at 39 for v1.x, and points contributors at external lang packs / `register_lang_packs()` for new languages.

## Test plan
- [x] README renders; link to Lang Packs section is valid