### PR TITLE
Fix quote/paren end finder and improve flattened list adjacency check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Double boundary for `.\n`** ([#207](https://github.com/speedyk-005/yasbd-lib/pull/207)): `detect()` yielded two consecutive offsets for `.\n`, leaving an empty span when sentences were reconstructed. Added `\n` to the negative lookahead in `CANDIDATE_BOUNDARY_FINDER` so the terminator no longer creates a separate boundary when a newline follows.
+- **Flattened list segmentation** ([#211](https://github.com/speedyk-005/yasbd-lib/pull/211)): Guarded `QUOTE_AND_PAREN_END_FINDER` behind `inner_range` check and relaxed the adjacency check so list markers at varying distances are recognized as part of the same list.
 - **Vertical list detection for multi-digit numbers** ([#204](https://github.com/speedyk-005/yasbd-lib/pull/204)): Expanded VERTICAL_LIST_START_FINDER quantifier to `{1,4}` and added `re.M` flag so multi-digit list markers at any line start are not mistaken for sentence boundaries.
 
 ### Removed

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -365,10 +365,11 @@ class Rules:
             }
             sentence_boundaries.difference_update(inner_range)
 
-            sentence_boundaries.update(
-                m.end() for m in self.QUOTE_AND_PAREN_END_FINDER.finditer(text)
-                if m.end() not in inner_range
-            )
+            if inner_range:
+                sentence_boundaries.update(
+                    m.end() for m in self.QUOTE_AND_PAREN_END_FINDER.finditer(text)
+                    if m.end() not in inner_range
+                )
 
     def _remove_toc_spans(
         self, sentence_boundaries: set[int], text: str
@@ -393,9 +394,10 @@ class Rules:
                 or text[horiz_matches[0].start()] == text.lstrip()[0]
             )
 
-            # List markers are close enough to belong to the same flattened list
-            and all(
-                b.start() - a.end() < 40
+            # At least one pair of list markers is close enough to belong
+            # to the same flattened list
+            and any(
+                4 < b.start() - a.end() < 40
                 for a, b in pairwise(horiz_matches)
             )
         )

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -188,7 +188,7 @@ def test_rule_cache_lru(en_detector):
         "12. The first item.\n|13. The second item.",
         "    A12. The first item.\n|    B13. The second item.",
 
-        # Flattened list items
+        # Flattened list items (fix for #208)
         "• 9. The first item.| • 10. The second item",
         "α· Πρώτο θέμα| β· Δεύτερο θέμα.",
         "The requirements are simple:| 1.) Python 3.12 environment.| 2. At least 8GB of RAM.",

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -187,6 +187,11 @@ def test_rule_cache_lru(en_detector):
         # Multi-digit vertical list items
         "12. The first item.\n|13. The second item.",
         "    A12. The first item.\n|    B13. The second item.",
+
+        # Flattened list items
+        "• 9. The first item.| • 10. The second item",
+        "α· Πρώτο θέμα| β· Δεύτερο θέμα.",
+        "The requirements are simple:| 1.) Python 3.12 environment.| 2. At least 8GB of RAM.",
     ],
 )
 def test_universal_regression(en_detector, marked_text):


### PR DESCRIPTION
## Objective

Flattened list text with bullet points, numbered items, markdown dashes, and Greek list markers gets split incorrectly. The horizontal list finder misses list items or splits them at the wrong place.

## Changes

- Guarded `QUOTE_AND_PAREN_END_FINDER` behind an `if inner_range` check so it doesn't run when there are no quoted or parenthesized spans to search for.
- Changed the flattened-list adjacency check from `all(... < 40)` to `any(4 < ... < 40)` so list items don't need to be maximally dense to be recognized as part of the same list.
- Added regression test cases for bullet+number combos (`• 9.`), Greek list markers (`α· β·`), and inline numbered items (`1.) 2.`).

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [x] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [ ] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #208