### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - name: Checkout Code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Simplified `TextSpan.__eq__` with `all()` for cleaner `hasattr` checks.
   - Fixed double spaces after commas (nl, my, sv, tr, id) and double space after operator (bg).
 - **Merged "Pronouns & Demonstratives" header into "Pronouns"** ([#196](https://github.com/speedyk-005/yasbd-lib/pull/196)): comment-only change in id.py and vi.py.
+- **Python 3.10 support** ([#212](https://github.com/speedyk-005/yasbd-lib/pull/212)): Lowered minimum from 3.11 to 3.10. Added classifier and CI entry.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ bench = [
   "pysbd",
   "sentencex",
   "sentsplit",  # depends on deprecated pkg_resources — needs setuptools<81
-  "nupunkt",
+  "nupunkt; python_version >= '3.11'",
   "blingfire",
   "sentence-splitter",
   "setuptools<81",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ python_files = "test_*.py"
 omit = ["*/_template.py", "*/cleaner_stub.py", "*/cli.py"]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"
 line-length = 95
 
 [tool.ruff.lint]
@@ -139,7 +139,7 @@ select = [
     "UP",     # Python syntax and API modernization (pyupgrade)
     "W",      # pycodestyle warnings
 ]
-ignore = ["PLW2901", "COM812", "D203", "D213", "RUF001", "RUF003", "RUF012", "S311", "FURB167", "PLC0206", "PLC0415"]
+ignore = ["PLW2901", "COM812", "D203", "D213", "RUF001", "RUF003", "RUF012", "S311", "FURB167", "PLC0206", "PLC0415", "PERF203"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403", "I001"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,14 @@ authors = [
 
 license = "MPL-2.0"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
## Objective

Lower the minimum Python version from 3.11 to 3.10 so the library works on Debian stable, older CI runners, and enterprise environments where 3.10 is still the default.

## Changes

- Dropped `requires-python` from `>=3.11` to `>=3.10`.
- Added `Programming Language :: Python :: 3.10` classifier.
- Marked `nupunkt` bench dependency as 3.11+ only.
- Lowered ruff `target-version` to `py310` and ignored `PERF203` (try/except in loop is only cheap on 3.11+).
- Added 3.10 to the CI test matrix.

No 3.11-only syntax was in use. The only possessive quantifier (`\s*+`) is handled by the `regex` third-party library, which supports it on any Python version.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [x] Documentation update / support
- [ ] Other (please describe):

## Verification

- [ ] I ran `pytest` and all tests pass.
- [ ] I ran `ruff format . && ruff check --fix .`.
- [ ] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Closes #206
