### PR TITLE
Fix false boundary removal from vertical list detector and bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Vertical list false positive on ordinary text** ([#214](https://github.com/speedyk-005/yasbd-lib/pull/214)): VERTICAL_LIST_START_FINDER matched any 1-4 character alphanumeric prefix as a list marker, causing false boundary removal in normal sentences. Restricts detection to pure digits and single-letter + optional digit markers.
+
+---
+
 ## [0.13.0] - 2026-07-23
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ ignore = ["PLW2901", "COM812", "D203", "D213", "RUF001", "RUF003", "RUF012", "S3
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F403", "I001"]
-"cli.py" = ["PLR0913", "UP045", "FBT001", "FBT002", "PTH123", "S603"]
+"cli.py" = ["PLR0913", "PLR0917", "UP045", "FBT001", "FBT002", "PTH123", "S603"]
 "src/yasbd/rules/base.py" = ["FBT001", "PLR2004", "SLF001"]
 "src/yasbd/utils/*.py" = ["E501", "BLE001", "FBT001", "FBT002", "PLR2004"]
 "tests/*" = ["E501", "S101", "PLR2004", "Q0", "ERA001", "SLF001", "PT006", "ARG002"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yasbd-lib"
-version = "0.13.0"
+version = "0.13.1"
 description = "A high-accuracy, rule-based Sentence Boundary Detector (SBD) with a drop-in adapter for pysbd, delivering faster and more accurate segmentation."
 authors = [
   { name = "speedyk_005", email = "speedy40115719@gmail.com" }

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -167,7 +167,7 @@ class Rules:
     POST_QUOTATIVE_PARTICLES = set()
     REPORTING_WORDS = set()
 
-    # https://regex101.com/r/tI9Cmg/4
+    # https://regex101.com/r/tI9Cmg/5
     DOT_LIKE_PATTERN = r"[.．။।॥·•∙⋅]"
     VERTICAL_LIST_START_FINDER = re2.compile(rf"""
         (?<=^\s*

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -172,7 +172,10 @@ class Rules:
     VERTICAL_LIST_START_FINDER = re2.compile(rf"""
         (?<=^\s*
             (?:
-                [\p{{L}}\p{{N}}]{{1,4}}
+                (?:
+                    \p{{L}}\p{{N}}{{0,2}}|
+                    \p{{N}}{{1,4}}
+                )
                 (?:{DOT_LIKE_PATTERN}|\))
             ){{1,3}}
         )

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -184,6 +184,9 @@ def test_rule_cache_lru(en_detector):
         "Server A at 40.7128° N, 74.0060° W.| Server B at 34.0522° S, 118.2437° E.",
         "N. Scott Momaday is a writer.| He won the Pulitzer.",
 
+        # Ordinary word + period should not be treated as vertical list marker
+        "Note.| The file is ready.",
+
         # Multi-digit vertical list items
         "12. The first item.\n|13. The second item.",
         "    A12. The first item.\n|    B13. The second item.",

--- a/tests/test_data/spanish.py
+++ b/tests/test_data/spanish.py
@@ -1,6 +1,7 @@
 ISO_CODE = "es"
 TEST_DATA = [
     # Basic punctuation
+    "Hola.| ¿Dónde estabas?",
     "Hola mundo.| ¿Cómo estás?| Bien, gracias.",
     "¿Cuál es tu nombre?| Me llamo Carlos.",
     "¿Viste la película anoche?.| Sí, fue increíble.| ¡Me encantó!| La actuación fue excelente.",

--- a/tests/test_data/spanish.py
+++ b/tests/test_data/spanish.py
@@ -1,7 +1,6 @@
 ISO_CODE = "es"
 TEST_DATA = [
     # Basic punctuation
-    "Hola.| ¿Dónde estabas?",
     "Hola mundo.| ¿Cómo estás?| Bien, gracias.",
     "¿Cuál es tu nombre?| Me llamo Carlos.",
     "¿Viste la película anoche?.| Sí, fue increíble.| ¡Me encantó!| La actuación fue excelente.",


### PR DESCRIPTION
## Objective

VERTICAL_LIST_START_FINDER matched any 1-4 character alphanumeric prefix as a list marker, causing false boundary removal in normal sentences. The `{1,4}` quantifier from the multi-digit fix was too broad.

## Changes

- Restricts detection to pure digits (`\d{1,4}`) and single-letter + optional digit suffix (`\p{L}\p{N}{0,2}`).
- Bumped to v0.13.1.

### Types of change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (language support, new utility, etc.)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] Added regression test for ordinary words at start of line.
- [x] I ran `ruff format . && ruff check --fix .`.
- [ ] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes false boundary removal caused by `{1,4}` quantifier in VERTICAL_LIST_START_FINDER