### PR TITLE
Use itertools.pairwise for adjacent boundary pairing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -21,5 +21,6 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@Rajesh270712](https://github.com/Rajesh270712)** | Base + English rule contributions |
 | **[@sanmaxdev](https://github.com/sanmaxdev)** | Language tag normalization helper |
 | **[@terminalchai](https://github.com/terminalchai)** | Burmese and Thai reporting words fix |
+| **[@XEDAB](https://github.com/XEDAB)** | Replaced manual adjacent boundary iteration with "itertools.pairwise" |
 
 Interested in contributing? See the [**Contributing Guide**](CONTRIBUTING.md) to get started!

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from collections.abc import Generator, Iterable
 from io import TextIOBase
-from itertools import chain, tee
+from itertools import chain, pairwise, tee
 
 from yasbd.exceptions import InvalidInputError
 from yasbd.rules import get_supported_langs, load_rule
@@ -125,8 +125,7 @@ class BoundaryDetector:
                 boundaries = [0, len(para)]
             else:
                 boundaries = rule.apply(para, self.preserve_quote_and_paren)
-
-            yield from ((boundaries[i], boundaries[i + 1]) for i in range(len(boundaries) - 1))
+            yield from pairwise(boundaries)
 
     @validate_input
     def detect(

--- a/src/yasbd/utils/pysbd_adapter.py
+++ b/src/yasbd/utils/pysbd_adapter.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterable
+from itertools import chain, pairwise
 from types import SimpleNamespace
 
 from yasbd import BoundaryDetector
@@ -111,13 +112,10 @@ class Segmenter:
         """Detect sentence boundaries in text."""
         if self.char_span:
             boundaries = list(self._detector.detect(text))
-
-            res = []
-            start = 0
-            for end in boundaries:
-                res.append(TextSpan(text[start:end], start, end))
-                start = end
-            return res
+            return [
+                TextSpan(text[start:end], start, end)
+                for start, end in pairwise(chain((0,), boundaries))
+            ]
 
         if self.clean:
             return list(self._detector.segment(text))


### PR DESCRIPTION
## Objective
Replace manual adjacent boundary iteration with itertools.pairwise
## Changes
Changed boundary_detector.py (added the pairwise import, and in _detect_relative_spans() swapped the generator expression in the return for pairwise(boundaries)) and pysbd_adapter.py (added the pairwise and chain imports, and changed _process_text()'s if self.char_span block from a res = [] + for-loop to pairwise(chain((0,), boundaries)))
### Types of change
- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues
Issue #216 [https://github.com/speedyk-005/yasbd-lib/issues/216](url)

Closes #216