### PR TITLE
Move trie pattern builder to utils and rename it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Trie pattern builder moved to utils and renamed** ([#230](https://github.com/speedyk-005/yasbd-lib/pull/230)): `build_abbr_pattern` moved from `yasbd.rules.base` to a new `yasbd.utils.trie` module and renamed to `build_optimized_pattern`. The old name stays as a backwards-compatible alias, and language rule files now import it from `yasbd.utils.trie`.
+
 ### [0.13.1] - 2026-07-18
 
 ### Fixed

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -2,20 +2,11 @@ import re  # For simpler patterns
 from itertools import pairwise
 
 import regex as re2
-from retrie.trie import Trie
 
+from yasbd.utils.trie import build_optimized_pattern
 
-def build_abbr_pattern(options: set[str]) -> str:
-    """Build an optimised and escaped regex alternation pattern.
-
-    Returns a never-match pattern if no valid options exist.
-    Ref: https://stackoverflow.com/questions/1723182/a-regex-that-will-never-be-matched-by-anything?
-    """
-    if not options:
-        return r"(?!)"
-
-    trie = Trie()
-    return trie.add(*options).pattern()
+# Backwards-compat alias for the pre-rename public API name.
+build_abbr_pattern = build_optimized_pattern
 
 
 class CJK:
@@ -221,9 +212,9 @@ class Rules:
         """Compile language-specific regex patterns."""
         cls.TERMINATORS_PATTERN = f"[{''.join(cls.TERMINATORS)}]"
         cls.DOTS_PATTERN = r"[.．]"
-        cls.TITLE_ABBRVS_PATTERN = build_abbr_pattern(cls.TITLE_ABBRVS)
-        cls.DOTTED_GEOPOL_ABBRVS_PATTERN = build_abbr_pattern(cls.DOTTED_GEOPOL_ABBRVS)
-        cls.COMMON_STARTERS_PATTERN = build_abbr_pattern(cls.COMMON_SENT_STARTERS)
+        cls.TITLE_ABBRVS_PATTERN = build_optimized_pattern(cls.TITLE_ABBRVS)
+        cls.DOTTED_GEOPOL_ABBRVS_PATTERN = build_optimized_pattern(cls.DOTTED_GEOPOL_ABBRVS)
+        cls.COMMON_STARTERS_PATTERN = build_optimized_pattern(cls.COMMON_SENT_STARTERS)
 
         # https://regex101.com/r/qBSyU5/19
         # Handle flattened lists due to messy OCR.
@@ -291,19 +282,19 @@ class Rules:
 
             # Abbrv that NEVER ends a sentence
             re.compile(
-               rf"\b(?i:{build_abbr_pattern(cls.INLINE_ONLY_ABBRVS)}){cls.DOTS_PATTERN}"
+               rf"\b(?i:{build_optimized_pattern(cls.INLINE_ONLY_ABBRVS)}){cls.DOTS_PATTERN}"
             ),
 
             # References abbrv + number/letter/bracket (e.g., p. 55, app. A, et al. [2004])
             re2.compile(rf"""
-                \b(?i:{build_abbr_pattern(cls.REFERENCE_ABBRVS)}){cls.DOTS_PATTERN}
+                \b(?i:{build_optimized_pattern(cls.REFERENCE_ABBRVS)}){cls.DOTS_PATTERN}
                 (?=\s+(?:\(|\[|\p{{Lu}}\b|\p{{N}}|[IVXLCDM]+))
                 """, re2.X
             ),
 
             # Date abbrv followed by a number
             re2.compile(
-                rf"\b(?i:{build_abbr_pattern(cls.DATE_ABBRVS)}){cls.DOTS_PATTERN}(?=\s+\p{{N}})"
+                rf"\b(?i:{build_optimized_pattern(cls.DATE_ABBRVS)}){cls.DOTS_PATTERN}(?=\s+\p{{N}})"
             ),
 
             # A dot followed by an superscript indicator (e.g. n.º, ​1.º)
@@ -323,14 +314,14 @@ class Rules:
                 """, re2.X
             ),
             re.compile(rf"""
-                (?:(?i:{build_abbr_pattern(cls.NAMES_WITH_EXCLAMATION)})[! ！‼])
+                (?:(?i:{build_optimized_pattern(cls.NAMES_WITH_EXCLAMATION)})[! ！‼])
                 (?!\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)
                """, re.X
             ),
 
             # structural headings (e.g., "Section 1. The Beginning.")
             re.compile(rf"""
-                \b(?:{build_abbr_pattern(cls.SECTION_MARKERS)})\s+
+                \b(?:{build_optimized_pattern(cls.SECTION_MARKERS)})\s+
                 (?:[\dIVXLCDM]+{cls.DOTS_PATTERN}){{1,3}}
                 """, re.X
             )
@@ -345,7 +336,7 @@ class Rules:
             )
             (?!  # NOT followed by any continuation markers, punctuation, or space+lowercase
                 \s*[\p{{Po}}\p{{Ll}}\p{{Pe}}]|
-                {build_abbr_pattern(cls.POST_QUOTATIVE_PARTICLES | cls.REPORTING_WORDS)}
+                {build_optimized_pattern(cls.POST_QUOTATIVE_PARTICLES | cls.REPORTING_WORDS)}
             )
             """,
             re2.X,

--- a/src/yasbd/rules/de.py
+++ b/src/yasbd/rules/de.py
@@ -1,6 +1,7 @@
 import re
 
-from yasbd.rules.base import Rules, build_abbr_pattern
+from yasbd.rules.base import Rules
+from yasbd.utils.trie import build_optimized_pattern
 
 
 # fmt: off
@@ -124,7 +125,7 @@ class DeRules(Rules):
             re.compile(rf"""
                 (?:\d\.|(?:(?<=\d)|\b)(?i:[ap]\.m\.))
                 (?=
-                    \s+(?i:{build_abbr_pattern(cls.DATE_ABBRVS | cls.DATE_WORDS)})
+                    \s+(?i:{build_optimized_pattern(cls.DATE_ABBRVS | cls.DATE_WORDS)})
                     (?:\.|\s|$)
                 )
             """, re.X),
@@ -132,7 +133,7 @@ class DeRules(Rules):
 
         # Street abbrv followed by a common starters
         cls.ENDING_STREET_ABBRVS_FINDER = re.compile(rf"""
-            (?:\b(?i:{build_abbr_pattern(cls.STREET_ABBRVS)})\.)
+            (?:\b(?i:{build_optimized_pattern(cls.STREET_ABBRVS)})\.)
             (?=\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)
            """, re.X
         )

--- a/src/yasbd/rules/en.py
+++ b/src/yasbd/rules/en.py
@@ -1,6 +1,7 @@
 import re
 
-from yasbd.rules.base import Rules, build_abbr_pattern
+from yasbd.rules.base import Rules
+from yasbd.utils.trie import build_optimized_pattern
 
 
 # fmt: off
@@ -93,7 +94,7 @@ class EnRules(Rules):
             # Geopolitical abbrv is followed by a common org noun (e.g., U.S.A Army)
             re.compile(rf"""
                 \b(?i:{cls.DOTTED_GEOPOL_ABBRVS_PATTERN})\.
-                (?=\s+(?:{build_abbr_pattern(cls.ORG_PROPER_NOUNS)}))
+                (?=\s+(?:{build_optimized_pattern(cls.ORG_PROPER_NOUNS)}))
                 """, re.X
             ),
 
@@ -101,7 +102,7 @@ class EnRules(Rules):
             re.compile(rf"""
                 (?:(?<=\d)|\b)(?i:[ap]\.m\.)
                 (?=
-                    \s+(?i:{build_abbr_pattern(cls.DATE_ABBRVS | cls.DATE_WORDS)})
+                    \s+(?i:{build_optimized_pattern(cls.DATE_ABBRVS | cls.DATE_WORDS)})
                     (?:\.|\s|$)
                 )
             """, re.X),
@@ -109,7 +110,7 @@ class EnRules(Rules):
 
         # Street abbrv followed by a common starters
         cls.ENDING_STREET_ABBRVS_FINDER = re.compile(rf"""
-            (?:\b(?i:{build_abbr_pattern(cls.STREET_ABBRVS)})\.)
+            (?:\b(?i:{build_optimized_pattern(cls.STREET_ABBRVS)})\.)
             (?=\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)
            """, re.X
         )

--- a/src/yasbd/rules/es.py
+++ b/src/yasbd/rules/es.py
@@ -1,6 +1,7 @@
 import regex as re
 
-from yasbd.rules.base import Rules, build_abbr_pattern
+from yasbd.rules.base import Rules
+from yasbd.utils.trie import build_optimized_pattern
 
 
 # fmt: off
@@ -95,7 +96,7 @@ class EsRules(Rules):
         # Resolves the ambiguity "Ud. Marco" vs "Ud. Mañana".
         cls.MID_SENTENCE_FINDER_LST.append(
             re.compile(rf"""
-                \b(?i:{build_abbr_pattern({"ud", "uds", "vd", "vds"})})\.
+                \b(?i:{build_optimized_pattern({"ud", "uds", "vd", "vds"})})\.
                 (?!\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)
             """, re.X)
         )

--- a/src/yasbd/rules/my.py
+++ b/src/yasbd/rules/my.py
@@ -1,6 +1,7 @@
 import re
 
-from yasbd.rules.base import Rules, build_abbr_pattern
+from yasbd.rules.base import Rules
+from yasbd.utils.trie import build_optimized_pattern
 
 
 # fmt: off
@@ -77,7 +78,7 @@ class MyRules(Rules):
         super()._compile_regex_dynamically()
 
         cls.FINAL_PARTICLES_FINDER = re.compile(
-            rf"{build_abbr_pattern(cls.DISCOURSE_FINAL_PARTICLES)}(?!\s*[.?!;:။၏])"
+            rf"{build_optimized_pattern(cls.DISCOURSE_FINAL_PARTICLES)}(?!\s*[.?!;:။၏])"
         )
 
     def post_process_boundaries(

--- a/src/yasbd/rules/th.py
+++ b/src/yasbd/rules/th.py
@@ -1,7 +1,8 @@
 import re
 from itertools import chain
 
-from yasbd.rules.base import Rules, build_abbr_pattern
+from yasbd.rules.base import Rules
+from yasbd.utils.trie import build_optimized_pattern
 
 
 # fmt: off
@@ -64,7 +65,7 @@ class ThRules(Rules):
         super()._compile_regex_dynamically()
 
         cls.FINAL_PARTICLES_FINDER = re.compile(
-            rf"{build_abbr_pattern(cls.DISCOURSE_FINAL_PARTICLES)}(?![\s]*[.?!;:๚๛])"
+            rf"{build_optimized_pattern(cls.DISCOURSE_FINAL_PARTICLES)}(?![\s]*[.?!;:๚๛])"
         )
 
         cls.SPACE_PLUS_STARTER_FINDER = re.compile(

--- a/src/yasbd/utils/trie.py
+++ b/src/yasbd/utils/trie.py
@@ -1,0 +1,14 @@
+from retrie.trie import Trie
+
+
+def build_optimized_pattern(options: set[str]) -> str:
+    """Build an optimised and escaped regex alternation pattern.
+
+    Returns a never-match pattern if no valid options exist.
+    Ref: https://stackoverflow.com/questions/1723182/a-regex-that-will-never-be-matched-by-anything?
+    """
+    if not options:
+        return r"(?!)"
+
+    trie = Trie()
+    return trie.add(*options).pattern()


### PR DESCRIPTION
## Objective

Move the trie-based regex pattern builder out of the rules module and into a shared utility, and give it a name that reflects what it does rather than one specific use case.

## Changes

- `build_abbr_pattern` moved from `src/yasbd/rules/base.py` to a new `src/yasbd/utils/trie.py` module.
- Renamed to `build_optimized_pattern`; the old name stays as a backwards-compat alias in `base.py`.
- Language rule files (`en`, `es`, `de`, `my`, `th`) now import it from `yasbd.utils.trie` instead of `yasbd.rules.base`.

### Types of change

<!-- What type of change does your PR cover? Put an `x` in the box that applies. -->

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [ ] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- No related issues
