### PR TITLE
Add post-processing hook to BoundaryDetector

### DIFF
--- a/API_REFERENCES.md
+++ b/API_REFERENCES.md
@@ -3,6 +3,7 @@
 * [yasbd](#yasbd)
   * [register\_spacy\_component](#yasbd.register_spacy_component)
 * [yasbd.boundary\_detector](#yasbd.boundary_detector)
+  * [HookContext](#yasbd.boundary_detector.HookContext)
   * [BoundaryDetector](#yasbd.boundary_detector.BoundaryDetector)
     * [\_\_init\_\_](#yasbd.boundary_detector.BoundaryDetector.__init__)
     * [lang](#yasbd.boundary_detector.BoundaryDetector.lang)
@@ -20,6 +21,7 @@
   * [InvalidInputError](#yasbd.exceptions.InvalidInputError)
   * [LangPackError](#yasbd.exceptions.LangPackError)
   * [CleanStepError](#yasbd.exceptions.CleanStepError)
+  * [HookError](#yasbd.exceptions.HookError)
 * [yasbd.rules](#yasbd.rules)
   * [register\_lang\_packs](#yasbd.rules.register_lang_packs)
   * [clear\_lang\_packs](#yasbd.rules.clear_lang_packs)
@@ -29,7 +31,6 @@
 * [yasbd.rules.am](#yasbd.rules.am)
 * [yasbd.rules.ar](#yasbd.rules.ar)
 * [yasbd.rules.base](#yasbd.rules.base)
-  * [build\_abbr\_pattern](#yasbd.rules.base.build_abbr_pattern)
   * [CJK](#yasbd.rules.base.CJK)
   * [Rules](#yasbd.rules.base.Rules)
     * [\_\_init\_\_](#yasbd.rules.base.Rules.__init__)
@@ -98,6 +99,8 @@
   * [YasbdComponent](#yasbd.utils.spacy_component.YasbdComponent)
     * [\_\_call\_\_](#yasbd.utils.spacy_component.YasbdComponent.__call__)
   * [create\_yasbd](#yasbd.utils.spacy_component.create_yasbd)
+* [yasbd.utils.trie](#yasbd.utils.trie)
+  * [build\_optimized\_pattern](#yasbd.utils.trie.build_optimized_pattern)
 
 <a id="yasbd"></a>
 
@@ -128,6 +131,25 @@ Examples
 
 # yasbd.boundary\_detector
 
+<a id="yasbd.boundary_detector.HookContext"></a>
+
+## HookContext Objects
+
+```python
+class HookContext(TypedDict)
+```
+
+Per-paragraph context passed to a post-processing hook.
+
+Keys:
+    text: The paragraph text being segmented.
+    lang: ISO language code of the active rule set.
+    boundaries: Paragraph-relative boundary offsets. Mutate this list
+        in place to add or remove sentence boundaries; reassigning
+        ``ctx["boundaries"]`` to a new list also works, though it is
+        not recommended.
+    paragraph_index: Zero-based index of the paragraph in the stream.
+
 <a id="yasbd.boundary_detector.BoundaryDetector"></a>
 
 ## BoundaryDetector Objects
@@ -145,7 +167,8 @@ class BoundaryDetector()
 def __init__(lang: str | None = None,
              *,
              preserve_quote_and_paren: bool = True,
-             verbose: bool = False)
+             verbose: bool = False,
+             hook: Callable[[HookContext], None] | None = None)
 ```
 
 Initialize the boundary detector.
@@ -159,6 +182,12 @@ Initialize the boundary detector.
 - `preserve_quote_and_paren` - Do not split on terminators inside
   quoted or parenthesised text.
 - `verbose` - Enable verbose logging.
+- `hook` - Optional per-paragraph post-processing callback. Receives
+  a dict with ``text``, ``lang``, ``boundaries`` and
+  ``paragraph_index`` keys; mutate ``boundaries`` in place to
+  add or remove sentence boundaries. Reassigning
+  ``ctx["boundaries"]`` to a new list also works, though
+  in-place mutation is recommended.
 
 <a id="yasbd.boundary_detector.BoundaryDetector.lang"></a>
 
@@ -415,6 +444,16 @@ class CleanStepError(YasbdError, TypeError)
 
 Raised when a StreamCleaner extra step fails (non-callable or non-str return).
 
+<a id="yasbd.exceptions.HookError"></a>
+
+## HookError Objects
+
+```python
+class HookError(YasbdError, RuntimeError)
+```
+
+Raised when a post-processing hook fails or leaves invalid boundaries.
+
 <a id="yasbd.rules"></a>
 
 # yasbd.rules
@@ -513,19 +552,6 @@ Checks the language pack registry first; falls back to the built-in rules direct
 <a id="yasbd.rules.base"></a>
 
 # yasbd.rules.base
-
-<a id="yasbd.rules.base.build_abbr_pattern"></a>
-
-#### build\_abbr\_pattern
-
-```python
-def build_abbr_pattern(options: set[str]) -> str
-```
-
-Build an optimised and escaped regex alternation pattern.
-
-Returns a never-match pattern if no valid options exist.
-Ref: https://stackoverflow.com/questions/1723182/a-regex-that-will-never-be-matched-by-anything?
 
 <a id="yasbd.rules.base.CJK"></a>
 
@@ -778,8 +804,8 @@ and various regex cleanup rules across paragraphs.
   ['WORD']
   >>> list(StreamCleaner("An hyphe-\nnated sentence"))
   ['An hyphenated sentence']
-  >>> list(StreamCleaner("Don't be naï-\nve"))
-  ["Don't be naïve"]
+  >>> list(StreamCleaner("state-of-the-\nart"))
+  ['state-of-the-art']
   >>> list(StreamCleaner(""))
   []
   >>> StreamCleaner("Hello world", steps_to_skip=["nothing"])
@@ -1180,4 +1206,21 @@ def create_yasbd(nlp: Language, name: str, lang: str | None,
 ```
 
 Create a spaCy component powered by yasbd.
+
+<a id="yasbd.utils.trie"></a>
+
+# yasbd.utils.trie
+
+<a id="yasbd.utils.trie.build_optimized_pattern"></a>
+
+#### build\_optimized\_pattern
+
+```python
+def build_optimized_pattern(options: set[str]) -> str
+```
+
+Build an optimised and escaped regex alternation pattern.
+
+Returns a never-match pattern if no valid options exist.
+Ref: https://stackoverflow.com/questions/1723182/a-regex-that-will-never-be-matched-by-anything?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Post-processing hook on BoundaryDetector** ([#234](https://github.com/speedyk-005/yasbd-lib/pull/234)): `BoundaryDetector` now accepts a `hook` callback that runs per paragraph after the language rules apply. It receives a dict with `text`, `lang`, `boundaries` and `paragraph_index` keys and can add or remove sentence boundaries in place. A new `HookError` is raised if the hook fails or leaves invalid boundaries. This replaces monkey-patching rule internals for custom boundary logic (e.g. OpenMed's `_split_yasbd_chinese_semicolons` hack).
+
 ### Changed
 
 - **Trie pattern builder moved to utils and renamed** ([#230](https://github.com/speedyk-005/yasbd-lib/pull/230)): `build_abbr_pattern` moved from `yasbd.rules.base` to a new `yasbd.utils.trie` module and renamed to `build_optimized_pattern`. The old name stays as a backwards-compatible alias, and language rule files now import it from `yasbd.utils.trie`.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ detector = BoundaryDetector(
 
     # Enable verbose logging. Defaults to `False`.
     verbose=True,
+
+    # Optional per-paragraph post-processing callback.
+    # Receives a dict with `text`, `lang`, and `boundaries` keys.
+    # Mutate `boundaries` (list of paragraph-relative offsets) in place
+    # to add or remove sentence boundaries. Defaults to `None`.
+    hook=lambda ctx: ...,
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -238,9 +238,10 @@ detector = BoundaryDetector(
     verbose=True,
 
     # Optional per-paragraph post-processing callback.
-    # Receives a dict with `text`, `lang`, and `boundaries` keys.
-    # Mutate `boundaries` (list of paragraph-relative offsets) in place
-    # to add or remove sentence boundaries. Defaults to `None`.
+    # Receives a dict with `text`, `lang`, `boundaries`, and
+    # `paragraph_index` keys. Mutate `boundaries` (list of
+    # paragraph-relative offsets) in place to add or remove
+    # sentence boundaries. Defaults to `None`.
     hook=lambda ctx: ...,
 )
 ```

--- a/README.md
+++ b/README.md
@@ -239,9 +239,9 @@ detector = BoundaryDetector(
 
     # Optional per-paragraph post-processing callback.
     # Receives a dict with `text`, `lang`, `boundaries`, and
-    # `paragraph_index` keys. Mutate `boundaries` (list of
-    # paragraph-relative offsets) in place to add or remove
-    # sentence boundaries. Defaults to `None`.
+    # `paragraph_index` keys. Mutate `boundaries` in place to add or
+    # remove sentence boundaries; reassigning `ctx["boundaries"]` to a
+    # new list also works, though it isn't recommended. Defaults to `None`.
     hook=lambda ctx: ...,
 )
 ```

--- a/src/yasbd/__init__.py
+++ b/src/yasbd/__init__.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from yasbd.boundary_detector import BoundaryDetector
 from yasbd.boundary_detector import ParagraphEOF
 from yasbd.exceptions import CleanStepError
+from yasbd.exceptions import HookError
 from yasbd.exceptions import InvalidInputError
 from yasbd.exceptions import UnsupportedLanguageError
 from yasbd.exceptions import YasbdError
@@ -43,6 +44,7 @@ if _utils_path not in __path__:
 __all__ = [
     "BoundaryDetector",
     "CleanStepError",
+    "HookError",
     "InvalidInputError",
     "ParagraphEOF",
     "UnsupportedLanguageError",

--- a/src/yasbd/__init__.py
+++ b/src/yasbd/__init__.py
@@ -2,6 +2,7 @@ from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 from yasbd.boundary_detector import BoundaryDetector
+from yasbd.boundary_detector import HookContext
 from yasbd.boundary_detector import ParagraphEOF
 from yasbd.exceptions import CleanStepError
 from yasbd.exceptions import HookError
@@ -44,6 +45,7 @@ if _utils_path not in __path__:
 __all__ = [
     "BoundaryDetector",
     "CleanStepError",
+    "HookContext",
     "HookError",
     "InvalidInputError",
     "ParagraphEOF",

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -24,7 +24,9 @@ class HookContext(TypedDict):
         text: The paragraph text being segmented.
         lang: ISO language code of the active rule set.
         boundaries: Paragraph-relative boundary offsets. Mutate this list
-            in place to add or remove sentence boundaries.
+            in place to add or remove sentence boundaries; reassigning
+            ``ctx["boundaries"]`` to a new list also works, though it is
+            not recommended.
         paragraph_index: Zero-based index of the paragraph in the stream.
     """
 
@@ -63,9 +65,10 @@ class BoundaryDetector:
             verbose: Enable verbose logging.
             hook: Optional per-paragraph post-processing callback. Receives
                 a dict with ``text``, ``lang``, ``boundaries`` and
-                ``paragraph_index`` keys; mutate ``boundaries`` (a list of
-                paragraph-relative offsets) in place to add or remove
-                sentence boundaries.
+                ``paragraph_index`` keys; mutate ``boundaries`` in place to
+                add or remove sentence boundaries. Reassigning
+                ``ctx["boundaries"]`` to a new list also works, though
+                in-place mutation is recommended.
         """
         self.preserve_quote_and_paren = preserve_quote_and_paren
         self.verbose = verbose
@@ -141,8 +144,9 @@ class BoundaryDetector:
     def _run_hook(self, text: str, boundaries: list[int], para_index: int) -> list[int]:
         """Run the user hook on *boundaries* for *text*, if configured.
 
-        The hook mutates ``boundaries`` in place. Returns the (possibly
-        re-sorted) list.
+        The hook may mutate the list in place or reassign
+        ``ctx["boundaries"]`` to a new list. The final value is validated
+        and returned (re-sorted).
         """
         if self.hook is None:
             return boundaries

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -136,9 +136,7 @@ class BoundaryDetector:
         try:
             self.hook(ctx)
         except Exception as exc:
-            raise HookError(
-                f"post-processing hook raised an error: {exc!r}"
-            ) from exc
+            raise HookError(f"post-processing hook raised an error: {exc!r}") from exc
 
         result = ctx["boundaries"]
         if not isinstance(result, list) or not all(

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -141,7 +141,7 @@ class BoundaryDetector:
 
         return rule
 
-    def _run_hook(self, text: str, boundaries: list[int], para_index: int) -> list[int]:
+    def _run_hook(self, text: str, boundaries: list[int], index: int) -> list[int]:
         """Run the user hook on *boundaries* for *text*, if configured.
 
         The hook may mutate the list in place or reassign
@@ -154,7 +154,7 @@ class BoundaryDetector:
             "text": text,
             "lang": self._lang,
             "boundaries": boundaries,
-            "paragraph_index": para_index,
+            "paragraph_index": index,
         }
         try:
             self.hook(ctx)
@@ -185,12 +185,12 @@ class BoundaryDetector:
         first_para = next(para_iter, "")  # Needed for auto
         rule = self._get_rule(self._lang, first_para)
 
-        for para_index, para in enumerate(chain([first_para], para_iter)):
+        for index, para in enumerate(chain([first_para], para_iter)):
             if not para or para.isspace():
                 boundaries = [0, len(para)]
             else:
                 boundaries = rule.apply(para, self.preserve_quote_and_paren)
-                boundaries = self._run_hook(para, boundaries, para_index)
+                boundaries = self._run_hook(para, boundaries, index)
             yield from pairwise(boundaries)
 
     @validate_input
@@ -239,7 +239,7 @@ class BoundaryDetector:
 
         rule = self._get_rule(self._lang, first_para)
 
-        for para_index, para in enumerate(chain([first_para], para_iter)):
+        for index, para in enumerate(chain([first_para], para_iter)):
             if para.isspace():
                 continue
 
@@ -249,7 +249,7 @@ class BoundaryDetector:
 
             stripped = para.rstrip()
             boundaries = rule.apply(stripped, self.preserve_quote_and_paren)
-            boundaries = self._run_hook(stripped, boundaries, para_index)
+            boundaries = self._run_hook(stripped, boundaries, index)
 
             for pos in boundaries[1:]:
                 yield offset + pos

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -1,5 +1,5 @@
 from collections import OrderedDict
-from collections.abc import Generator, Iterable
+from collections.abc import Callable, Generator, Iterable
 from io import TextIOBase
 from itertools import chain, pairwise, tee
 
@@ -30,6 +30,7 @@ class BoundaryDetector:
         *,
         preserve_quote_and_paren: bool = True,
         verbose: bool = False,
+        hook: Callable[[dict[str, object]], None] | None = None,
     ):
         """Initialize the boundary detector.
 
@@ -41,9 +42,14 @@ class BoundaryDetector:
             preserve_quote_and_paren: Do not split on terminators inside
                 quoted or parenthesised text.
             verbose: Enable verbose logging.
+            hook: Optional per-paragraph post-processing callback. Receives
+                a dict with ``text``, ``lang`` and ``boundaries`` keys;
+                mutate ``boundaries`` (a list of paragraph-relative offsets)
+                in place to add or remove sentence boundaries.
         """
         self.preserve_quote_and_paren = preserve_quote_and_paren
         self.verbose = verbose
+        self.hook = hook
         self._rule_cache: OrderedDict[str, object] = OrderedDict()
 
         if not lang:
@@ -112,6 +118,22 @@ class BoundaryDetector:
 
         return rule
 
+    def _run_hook(self, text: str, boundaries: list[int]) -> list[int]:
+        """Run the user hook on *boundaries* for *text*, if configured.
+
+        The hook mutates ``boundaries`` in place. Returns the (possibly
+        re-sorted) list.
+        """
+        if self.hook is None:
+            return boundaries
+        ctx: dict[str, object] = {
+            "text": text,
+            "lang": self._lang,
+            "boundaries": boundaries,
+        }
+        self.hook(ctx)
+        return sorted(ctx["boundaries"])
+
     def _detect_relative_spans(
         self,
         para_iter: Iterable[str],
@@ -125,6 +147,7 @@ class BoundaryDetector:
                 boundaries = [0, len(para)]
             else:
                 boundaries = rule.apply(para, self.preserve_quote_and_paren)
+                boundaries = self._run_hook(para, boundaries)
             yield from pairwise(boundaries)
 
     @validate_input
@@ -181,7 +204,9 @@ class BoundaryDetector:
                 yield ParagraphEOF
             is_first_para = False
 
-            boundaries = rule.apply(para.rstrip(), self.preserve_quote_and_paren)
+            stripped = para.rstrip()
+            boundaries = rule.apply(stripped, self.preserve_quote_and_paren)
+            boundaries = self._run_hook(stripped, boundaries)
 
             for pos in boundaries[1:]:
                 yield offset + pos

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 from collections.abc import Callable, Generator, Iterable
 from io import TextIOBase
 from itertools import chain, pairwise, tee
+from typing import TypedDict
 
 from yasbd.exceptions import HookError, InvalidInputError
 from yasbd.rules import get_supported_langs, load_rule
@@ -14,6 +15,24 @@ from yasbd.utils.paragraph_stream import ParagraphStream
 # Signals transition between paragraphs in relative mode
 # during boundary detection
 ParagraphEOF = type("_ParagraphEOF", (), {"__repr__": lambda _: "ParagraphEOF"})()
+
+
+class HookContext(TypedDict):
+    """Per-paragraph context passed to a post-processing hook.
+
+    Keys:
+        text: The paragraph text being segmented.
+        lang: ISO language code of the active rule set.
+        boundaries: Paragraph-relative boundary offsets. Mutate this list
+            in place to add or remove sentence boundaries.
+        paragraph_index: Zero-based index of the paragraph in the stream.
+    """
+
+    text: str
+    lang: str
+    boundaries: list[int]
+    paragraph_index: int
+
 
 # Confidence threshold for auto language detection
 _MIN_CONFIDENCE = 0.8
@@ -30,7 +49,7 @@ class BoundaryDetector:
         *,
         preserve_quote_and_paren: bool = True,
         verbose: bool = False,
-        hook: Callable[[dict[str, object]], None] | None = None,
+        hook: Callable[[HookContext], None] | None = None,
     ):
         """Initialize the boundary detector.
 
@@ -127,7 +146,7 @@ class BoundaryDetector:
         """
         if self.hook is None:
             return boundaries
-        ctx: dict[str, object] = {
+        ctx: HookContext = {
             "text": text,
             "lang": self._lang,
             "boundaries": boundaries,

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -169,6 +169,12 @@ class BoundaryDetector:
                 "post-processing hook must leave 'boundaries' as a list of "
                 "int offsets within the paragraph"
             )
+        if 0 not in result or len(text) not in result:
+            raise HookError(
+                "post-processing hook must keep both the paragraph start (0) "
+                "and end offset; use [0, len(text)] to merge the whole "
+                "paragraph into one sentence"
+            )
         return sorted(result)
 
     def _detect_relative_spans(

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -43,9 +43,10 @@ class BoundaryDetector:
                 quoted or parenthesised text.
             verbose: Enable verbose logging.
             hook: Optional per-paragraph post-processing callback. Receives
-                a dict with ``text``, ``lang`` and ``boundaries`` keys;
-                mutate ``boundaries`` (a list of paragraph-relative offsets)
-                in place to add or remove sentence boundaries.
+                a dict with ``text``, ``lang``, ``boundaries`` and
+                ``paragraph_index`` keys; mutate ``boundaries`` (a list of
+                paragraph-relative offsets) in place to add or remove
+                sentence boundaries.
         """
         self.preserve_quote_and_paren = preserve_quote_and_paren
         self.verbose = verbose
@@ -118,7 +119,7 @@ class BoundaryDetector:
 
         return rule
 
-    def _run_hook(self, text: str, boundaries: list[int]) -> list[int]:
+    def _run_hook(self, text: str, boundaries: list[int], para_index: int) -> list[int]:
         """Run the user hook on *boundaries* for *text*, if configured.
 
         The hook mutates ``boundaries`` in place. Returns the (possibly
@@ -130,6 +131,7 @@ class BoundaryDetector:
             "text": text,
             "lang": self._lang,
             "boundaries": boundaries,
+            "paragraph_index": para_index,
         }
         try:
             self.hook(ctx)
@@ -156,12 +158,12 @@ class BoundaryDetector:
         first_para = next(para_iter, "")  # Needed for auto
         rule = self._get_rule(self._lang, first_para)
 
-        for para in chain([first_para], para_iter):
+        for para_index, para in enumerate(chain([first_para], para_iter)):
             if not para or para.isspace():
                 boundaries = [0, len(para)]
             else:
                 boundaries = rule.apply(para, self.preserve_quote_and_paren)
-                boundaries = self._run_hook(para, boundaries)
+                boundaries = self._run_hook(para, boundaries, para_index)
             yield from pairwise(boundaries)
 
     @validate_input
@@ -210,7 +212,7 @@ class BoundaryDetector:
 
         rule = self._get_rule(self._lang, first_para)
 
-        for para in chain([first_para], para_iter):
+        for para_index, para in enumerate(chain([first_para], para_iter)):
             if para.isspace():
                 continue
 
@@ -220,7 +222,7 @@ class BoundaryDetector:
 
             stripped = para.rstrip()
             boundaries = rule.apply(stripped, self.preserve_quote_and_paren)
-            boundaries = self._run_hook(stripped, boundaries)
+            boundaries = self._run_hook(stripped, boundaries, para_index)
 
             for pos in boundaries[1:]:
                 yield offset + pos

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -3,7 +3,7 @@ from collections.abc import Callable, Generator, Iterable
 from io import TextIOBase
 from itertools import chain, pairwise, tee
 
-from yasbd.exceptions import InvalidInputError
+from yasbd.exceptions import HookError, InvalidInputError
 from yasbd.rules import get_supported_langs, load_rule
 from yasbd.utils.cleaner_stub import StreamCleanerStub
 from yasbd.utils.input_validator import validate_input
@@ -131,8 +131,22 @@ class BoundaryDetector:
             "lang": self._lang,
             "boundaries": boundaries,
         }
-        self.hook(ctx)
-        return sorted(ctx["boundaries"])
+        try:
+            self.hook(ctx)
+        except Exception as exc:
+            raise HookError(
+                f"post-processing hook raised an error: {exc!r}"
+            ) from exc
+
+        result = ctx["boundaries"]
+        if not isinstance(result, list) or not all(
+            isinstance(pos, int) and 0 <= pos <= len(text) for pos in result
+        ):
+            raise HookError(
+                "post-processing hook must leave 'boundaries' as a list of "
+                "int offsets within the paragraph"
+            )
+        return sorted(result)
 
     def _detect_relative_spans(
         self,

--- a/src/yasbd/exceptions.py
+++ b/src/yasbd/exceptions.py
@@ -18,5 +18,5 @@ class CleanStepError(YasbdError, TypeError):
     """Raised when a StreamCleaner extra step fails (non-callable or non-str return)."""
 
 
-class HookError(YasbdError, TypeError):
+class HookError(YasbdError, RuntimeError):
     """Raised when a post-processing hook fails or leaves invalid boundaries."""

--- a/src/yasbd/exceptions.py
+++ b/src/yasbd/exceptions.py
@@ -16,3 +16,7 @@ class LangPackError(YasbdError):
 
 class CleanStepError(YasbdError, TypeError):
     """Raised when a StreamCleaner extra step fails (non-callable or non-str return)."""
+
+
+class HookError(YasbdError, TypeError):
+    """Raised when a post-processing hook fails or leaves invalid boundaries."""

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -204,3 +204,17 @@ def test_universal_regression(en_detector, marked_text):
 
     result = list(en_detector.segment(input_text))
     assert result == expected, f"Input: {input_text}"
+
+
+def test_post_processing_hook():
+    """test that a hook can remove and add boundaries in place."""
+
+    def tweak(ctx):
+        # Remove the boundary after "Hi." (join) and add one after "There" (split)
+        ctx["boundaries"] = [
+            pos for pos in ctx["boundaries"] if pos != 3
+        ] + [10]
+
+    detector = BoundaryDetector(lang="en", hook=tweak)
+    assert list(detector.segment("Hi. There world.")) == ["Hi. There", "world."]
+    assert list(detector.detect("Hi. There world.")) == [10, 16]


### PR DESCRIPTION
## Objective

Post-processing of sentence boundaries required reaching into yasbd internals (subclassing rules or monkey-patching `post_process_boundaries`), which breaks against the rule cache and leaks globally across detectors. This PR adds a first-class, per-instance hook to `BoundaryDetector` so users can adjust boundaries without touching private machinery.

## Changes

- Added `hook` parameter to `BoundaryDetector.__init__`. The callback receives a dict with `text`, `lang`, `boundaries`, and `paragraph_index` keys and mutates `boundaries` (a list of paragraph-relative offsets) in place to add or remove sentence boundaries.
- Added `HookError`, raised when a hook raises an exception or leaves `boundaries` in an invalid state (not a list of ints, or offsets outside the paragraph). Exported from the package root.
- The hook runs per paragraph in both `detect()` and `segment()`, after the language rules apply. Empty or whitespace-only paragraphs never invoke it.
- Documented in README; regression test covers removing and adding boundaries via the hook.

### Types of change

- [x] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass (98 passed, 2 skipped).
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- N/A

## Notes

The hook is designed to replace external hacks like OpenMed's `_split_yasbd_chinese_semicolons` ([openmed PR #2005](https://github.com/maziyarpanahi/openmed/pull/2005/changes/3441e8df8036ce69c4e245505b1d3b5bc3a4265d#diff-b45618f4953157ddc61a1751e7d41c6fe47e543b32d900c8e8cc3f01e0a169bfR307)), which re-splits returned spans with a second engine. The same behavior is now expressible in a two-line hook: `ctx["boundaries"].extend(m.end() for m in re.finditer("；", ctx["text"]))`.

It also supersedes the request in issue #7 for a `never_split_after` constructor parameter: custom no-split rules are now a small hook instead of new engine state.
