### PR TITLE
Fix absolute offsets when source begins with blank lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Hyphens dropped at line breaks in hyphenated compounds** ([#231](https://github.com/speedyk-005/yasbd-lib/pull/231)): StreamCleaner removed the hyphen when a line broke at a legitimate hyphenated compound, turning `state-of-the-\nart` into `state-of-theart`. Now only known prefixes/suffixes join across line breaks; all other cases keep the hyphen. Unicode hyphen variants are normalized to ASCII first.
+- **Absolute offsets ignore leading blank lines** ([#236](https://github.com/speedyk-005/yasbd-lib/pull/236)): `detect()` skipped whitespace-only paragraphs before accumulating the offset, so text starting with blank lines produced offsets relative to the first non-whitespace paragraph. Whitespace paragraphs now advance the offset.
 
 ### [0.13.1] - 2026-07-18
 

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -175,6 +175,8 @@ class BoundaryDetector:
 
         for para in chain([first_para], para_iter):
             if para.isspace():
+                if not relative:
+                    offset += len(para)
                 continue
 
             if relative and not is_first_para:

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -116,6 +116,21 @@ def test_detect_paragraph_eof_sentinel(en_detector):
     assert result == [6, 15]
 
 
+def test_detect_leading_blank_offset(en_detector):
+    """test that absolute offsets account for leading blank paragraphs."""
+    # Leading blank lines must shift absolute offsets (fix for openmed adapter)
+    result = list(en_detector.detect("\n\n\nOne. Two.\n\nThree."))
+    assert result == [7, 12, 20]
+
+    # Interior blank paragraphs counted too
+    result = list(en_detector.detect("One.\n\n\n\nTwo."))
+    assert result == [4, 12]
+
+    # No blank lines: unchanged
+    result = list(en_detector.detect("One. Two. Three."))
+    assert result == [4, 9, 16]
+
+
 def test_rule_cache_lru(en_detector):
     """test that rule objects are cached (max 5) and reused on lang switch."""
     # Same lang = same cached object


### PR DESCRIPTION
## Objective

`detect()` in absolute mode skipped whitespace-only paragraphs before accumulating the stream offset. When the source text started with blank lines, every reported boundary was short by the length of those leading blanks, so offsets were relative to the first non-whitespace paragraph instead of the true start of the source. Downstream consumers that slice the original text (e.g. the OpenMed yasbd adapter) had to strip the prefix and re-add it manually.

## Changes

- Whitespace-only paragraphs now advance the offset in `detect()` absolute mode, so leading blank lines are accounted for.
- `relative=True` mode is unaffected (no offset accumulation there).
- `segment()` is unaffected; paragraph-relative spans are unchanged.
- Regression test covers leading blanks, interior blank paragraphs, and the no-blank baseline.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass (98 passed, 2 skipped).
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- N/A (fixes offset bug surfaced while reviewing the [OpenMed yasbd adapter](https://github.com/maziyarpanahi/openmed/pull/2005))

## Notes

The OpenMed adapter ([openmed/processing/sentences.py](https://github.com/maziyarpanahi/openmed/blob/63a643da945bac3e9531b5aef34276cb21ced838/openmed/processing/sentences.py#L478-L484)) currently works around this with `span_offset = len(text) - len(text.lstrip())`; after this fix that workaround is unnecessary.
