### PR TITLE
Replace cleaning pipeline lambdas with named functions

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,5 +22,6 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@sanmaxdev](https://github.com/sanmaxdev)** | Language tag normalization helper |
 | **[@terminalchai](https://github.com/terminalchai)** | Burmese and Thai reporting words fix |
 | **[@XEDAB](https://github.com/XEDAB)** | Replaced manual adjacent boundary iteration with "itertools.pairwise" |
+| **[@AshSgDe29071999](https://github.com/AshSgDe29071999)** | Named cleaning-pipeline helpers for testability |
 
 Interested in contributing? See the [**Contributing Guide**](CONTRIBUTING.md) to get started!

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,25 +5,24 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | Name | Role |
 |------|------|
 | **[@speedyk-005](https://github.com/speedyk-005)** | Maintainer & Creator |
-| **[@AshSgDe29071999](https://github.com/AshSgDe29071999)** | Combined same-module imports in `__init__.py` |
 | **[@1cbyc](https://github.com/1cbyc)** | Coordinate direction abbreviation fix |
+| **[@AshSgDe29071999](https://github.com/AshSgDe29071999)** | Combined same-module imports in `__init__.py`; named cleaning-pipeline helpers for testability |
 | **[@cnaples79](https://github.com/cnaples79)** | Missing comma in set literals fix |
 | **[@ddelrio1986](https://github.com/ddelrio1986)** | Spelling and grammar fixes in docs |
+| **[@HeaTTap](https://github.com/HeaTTap)** | Line ending normalization in default cleaning pipeline |
 | **[@hkJerryLeung](https://github.com/hkJerryLeung)** | French `est` abbreviation fix |
 | **[@hongquan](https://github.com/hongquan)** | `py.typed` marker for PEP 561 compliance |
-| **[@HeaTTap](https://github.com/HeaTTap)** | Line ending normalization in default cleaning pipeline |
 | **[@Jah-yee](https://github.com/Jah-yee)** | Reference abbreviation bracketed citation fix |
 | **[@JheanLL](https://github.com/JheanLL)** | Trie prototype design & Spanish rule contributions |
 | **[@JosephM961](https://github.com/JosephM961)** | Documentation additions and typo fixes |
 | **[@k-anushka14](https://github.com/k-anushka14)** | Removed unused timeout parameter from external cleaner; merged Pronouns & Demonstratives header into Pronouns |
 | **[@kernelpanic888](https://github.com/kernelpanic888)** | Non-German ordinal boundary inheritance fix |
-| **[@MohammedAnasNathani](https://github.com/MohammedAnasNathani)** | Documentation for built-in language freeze |
-| **[@Mayankshrey438](https://github.com/Mayankshrey438)** | Armenian language support & flattened list heuristic |
 | **[@MasRama](https://github.com/MasRama)** | Double boundary for `.\n` fix |
+| **[@Mayankshrey438](https://github.com/Mayankshrey438)** | Armenian language support & flattened list heuristic |
+| **[@MohammedAnasNathani](https://github.com/MohammedAnasNathani)** | Documentation for built-in language freeze |
 | **[@Rajesh270712](https://github.com/Rajesh270712)** | Base + English rule contributions |
 | **[@sanmaxdev](https://github.com/sanmaxdev)** | Language tag normalization helper |
 | **[@terminalchai](https://github.com/terminalchai)** | Burmese and Thai reporting words fix |
 | **[@XEDAB](https://github.com/XEDAB)** | Replaced manual adjacent boundary iteration with "itertools.pairwise" |
-| **[@AshSgDe29071999](https://github.com/AshSgDe29071999)** | Named cleaning-pipeline helpers for testability |
 
 Interested in contributing? See the [**Contributing Guide**](CONTRIBUTING.md) to get started!

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -112,14 +112,24 @@ def _clean_ocr_text(text: str) -> str:
     return PAGE_FINDER.sub("", cleaned_text)
 
 
+
+def unwrap_htmls(text: str) -> str:
+    return text if "<" not in text else HTML_TAGS_FINDER.sub("", text)
+
+
+def normalize_slashes(text: str) -> str:
+    return text if "///" not in text else CONSECUTIVE_FORWARD_SLASH_FINDER.sub("", text)
+
+
+def normalize_spaces(text: str) -> str:
+    return text if " " not in text else MULTIPLE_SPACES_FINDER.sub(" ", text)
+
 DEFAULT_CLEANING_PIPELINE = {
     "fix_mojibake": ftfy.fix_text,
     "fix_ocr_text": _clean_ocr_text,
-    "unwrap_htmls": lambda t: t if "<" not in t else HTML_TAGS_FINDER.sub("", t),
-    "normalize_slashes": lambda t: (
-        t if "///" not in t else CONSECUTIVE_FORWARD_SLASH_FINDER.sub("", t)
-    ),
-    "normalize_spaces": lambda t: t if " " not in t else MULTIPLE_SPACES_FINDER.sub(" ", t),
+    "unwrap_htmls": unwrap_htmls,
+    "normalize_slashes": normalize_slashes,
+    "normalize_spaces": normalize_spaces,
 }
 
 

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -112,17 +112,20 @@ def _clean_ocr_text(text: str) -> str:
     return PAGE_FINDER.sub("", cleaned_text)
 
 
-
 def unwrap_htmls(text: str) -> str:
+    """Strip HTML tags only when the text actually contains angle brackets."""
     return text if "<" not in text else HTML_TAGS_FINDER.sub("", text)
 
 
 def normalize_slashes(text: str) -> str:
+    """Collapse runaway forward-slash runs used as OCR/layout artifacts."""
     return text if "///" not in text else CONSECUTIVE_FORWARD_SLASH_FINDER.sub("", text)
 
 
 def normalize_spaces(text: str) -> str:
+    """Collapse repeated spaces when present; skip the regex otherwise."""
     return text if " " not in text else MULTIPLE_SPACES_FINDER.sub(" ", text)
+
 
 DEFAULT_CLEANING_PIPELINE = {
     "fix_mojibake": ftfy.fix_text,

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -121,19 +121,16 @@ def _clean_ocr_text(text: str) -> str:
 
 def unwrap_htmls(text: str) -> str:
     """Strip HTML tags only when the text actually contains angle brackets."""
-    # Fast path: skip the HTML regex when no tags can be present.
     return text if "<" not in text else HTML_TAGS_FINDER.sub("", text)
 
 
 def normalize_slashes(text: str) -> str:
     """Collapse runaway forward-slash runs used as OCR/layout artifacts."""
-    # Only run the slash regex when a triple-slash run is present.
     return text if "///" not in text else CONSECUTIVE_FORWARD_SLASH_FINDER.sub("", text)
 
 
 def normalize_spaces(text: str) -> str:
     """Collapse repeated spaces when present; skip the regex otherwise."""
-    # Avoid the multi-space regex when the text has no spaces at all.
     return text if " " not in text else MULTIPLE_SPACES_FINDER.sub(" ", text)
 
 

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -114,16 +114,19 @@ def _clean_ocr_text(text: str) -> str:
 
 def unwrap_htmls(text: str) -> str:
     """Strip HTML tags only when the text actually contains angle brackets."""
+    # Fast path: skip the HTML regex when no tags can be present.
     return text if "<" not in text else HTML_TAGS_FINDER.sub("", text)
 
 
 def normalize_slashes(text: str) -> str:
     """Collapse runaway forward-slash runs used as OCR/layout artifacts."""
+    # Only run the slash regex when a triple-slash run is present.
     return text if "///" not in text else CONSECUTIVE_FORWARD_SLASH_FINDER.sub("", text)
 
 
 def normalize_spaces(text: str) -> str:
     """Collapse repeated spaces when present; skip the regex otherwise."""
+    # Avoid the multi-space regex when the text has no spaces at all.
     return text if " " not in text else MULTIPLE_SPACES_FINDER.sub(" ", text)
 
 


### PR DESCRIPTION
## Objective

Replace inline lambdas in `DEFAULT_CLEANING_PIPELINE` with named module-level callables so the pipeline is easier to test, document, and skip by name.

## Changes

- Added `unwrap_htmls`, `normalize_slashes`, and `normalize_spaces` as named helpers (with short docstrings and line comments for the fast-path guards).
- Wired them into `DEFAULT_CLEANING_PIPELINE` in place of the previous lambdas.
- Listed myself in `CONTRIBUTORS.md`.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [ ] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #237