### PR TITLE
Expand StreamCleaner SUFFIXES with common suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,3 +328,8 @@ Initial release.
 - **Drop-in PySBD compatibility**: Included a drop-in `Segmenter` adapter that mirrors `pysbd`'s API interface, exposing `segment()`, `clean`, and `char_span` capabilities.
 - **Flexible dual-mode API**: Exposes `detect()` for retrieving raw boundary offset slices and `segment()` for producing rich text string spans.
 - **Comprehensive benchmarking harness**: Bundles comparative analysis scripts comparing seven libraries across seven distinct edge-case scenarios.
+
+## [Unreleased]
+
+### Added
+- Expanded SUFFIXES in HYPHENATED_WORD_FINDER with common English suffixes (able, ed, ing, ive, ly, ment, ness, ous, ve)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,5 +23,5 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@sanmaxdev](https://github.com/sanmaxdev)** | Language tag normalization helper |
 | **[@terminalchai](https://github.com/terminalchai)** | Burmese and Thai reporting words fix |
 | **[@XEDAB](https://github.com/XEDAB)** | Replaced manual adjacent boundary iteration with "itertools.pairwise" |
-
+| **[@Girdharilal-aiml](https://github.com/Girdharilal-aiml)** | Expanded SUFFIXES with common English suffixes |
 Interested in contributing? See the [**Contributing Guide**](CONTRIBUTING.md) to get started!

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -21,7 +21,10 @@ PREFIXES = {
     "pseudo", "quasi", "re", "retro", "semi", "sub", "super", "supra",
     "tele", "trans", "tri", "ultra", "un", "uni", "phe", "ani",
 }
-SUFFIXES = {"sis", "tion", "ry", "nal", "mal", "no", "té"}
+SUFFIXES = {
+    "able", "ed", "ing", "ive", "ly", "ment", "ness", "ous", "tion",
+    "ve", "sis", "ry", "nal", "mal", "no", "té",
+}
 # fmt: on
 
 # https://regex101.com/r/dL1zCM/1


### PR DESCRIPTION
Fixes #244

Added common English suffixes to HYPHENATED_WORD_FINDER:
- able, ed, ing, ive, ly, ment, ness, ous, ve

This allows legitimate wrap-around joins like:
- work-\ning → working
- quick-\nly → quickly
- develop-\nment → development
- ha-\nve → have