### PR TITLE
Fix: remove destructive normalize_slashes step from StreamCleaner

### DIFF
--- a/API_REFERENCES.md
+++ b/API_REFERENCES.md
@@ -942,7 +942,6 @@ Implements the iterator protocol. Yields cleaned paragraph strings.
   - fix_mojibake
   - fix_ocr_text
   - unwrap_htmls
-  - normalize_slashes
   - normalize_spaces
 - `extra_steps` - Optional user-defined cleaning functions, run after built-in steps.
   Each function must accept and return ``str``.

--- a/API_REFERENCES.md
+++ b/API_REFERENCES.md
@@ -1,7 +1,5 @@
 # Table of Contents
 
-* [yasbd](#yasbd)
-  * [register\_spacy\_component](#yasbd.register_spacy_component)
 * [yasbd.boundary\_detector](#yasbd.boundary_detector)
   * [BoundaryDetector](#yasbd.boundary_detector.BoundaryDetector)
     * [\_\_init\_\_](#yasbd.boundary_detector.BoundaryDetector.__init__)
@@ -20,16 +18,12 @@
   * [InvalidInputError](#yasbd.exceptions.InvalidInputError)
   * [LangPackError](#yasbd.exceptions.LangPackError)
   * [CleanStepError](#yasbd.exceptions.CleanStepError)
-* [yasbd.rules](#yasbd.rules)
-  * [register\_lang\_packs](#yasbd.rules.register_lang_packs)
-  * [clear\_lang\_packs](#yasbd.rules.clear_lang_packs)
-  * [get\_supported\_langs](#yasbd.rules.get_supported_langs)
-  * [load\_rule](#yasbd.rules.load_rule)
+* [yasbd](#yasbd)
+  * [register\_spacy\_component](#yasbd.register_spacy_component)
 * [yasbd.rules.af](#yasbd.rules.af)
 * [yasbd.rules.am](#yasbd.rules.am)
 * [yasbd.rules.ar](#yasbd.rules.ar)
 * [yasbd.rules.base](#yasbd.rules.base)
-  * [build\_abbr\_pattern](#yasbd.rules.base.build_abbr_pattern)
   * [CJK](#yasbd.rules.base.CJK)
   * [Rules](#yasbd.rules.base.Rules)
     * [\_\_init\_\_](#yasbd.rules.base.Rules.__init__)
@@ -49,6 +43,11 @@
 * [yasbd.rules.ht](#yasbd.rules.ht)
 * [yasbd.rules.hy](#yasbd.rules.hy)
 * [yasbd.rules.id](#yasbd.rules.id)
+* [yasbd.rules](#yasbd.rules)
+  * [register\_lang\_packs](#yasbd.rules.register_lang_packs)
+  * [clear\_lang\_packs](#yasbd.rules.clear_lang_packs)
+  * [get\_supported\_langs](#yasbd.rules.get_supported_langs)
+  * [load\_rule](#yasbd.rules.load_rule)
 * [yasbd.rules.it](#yasbd.rules.it)
 * [yasbd.rules.ja](#yasbd.rules.ja)
 * [yasbd.rules.kk](#yasbd.rules.kk)
@@ -71,10 +70,11 @@
 * [yasbd.rules.ur](#yasbd.rules.ur)
 * [yasbd.rules.vi](#yasbd.rules.vi)
 * [yasbd.rules.zh](#yasbd.rules.zh)
-* [yasbd.utils](#yasbd.utils)
 * [yasbd.utils.cleaner](#yasbd.utils.cleaner)
+  * [normalize\_newlines](#yasbd.utils.cleaner.normalize_newlines)
   * [StreamCleaner](#yasbd.utils.cleaner.StreamCleaner)
     * [\_\_init\_\_](#yasbd.utils.cleaner.StreamCleaner.__init__)
+* [yasbd.utils](#yasbd.utils)
 * [yasbd.utils.input\_validator](#yasbd.utils.input_validator)
   * [validate\_input](#yasbd.utils.input_validator.validate_input)
 * [yasbd.utils.lang\_code\_normalizer](#yasbd.utils.lang_code_normalizer)
@@ -98,31 +98,8 @@
   * [YasbdComponent](#yasbd.utils.spacy_component.YasbdComponent)
     * [\_\_call\_\_](#yasbd.utils.spacy_component.YasbdComponent.__call__)
   * [create\_yasbd](#yasbd.utils.spacy_component.create_yasbd)
-
-<a id="yasbd"></a>
-
-# yasbd
-
-<a id="yasbd.register_spacy_component"></a>
-
-#### register\_spacy\_component
-
-```python
-def register_spacy_component()
-```
-
-Register the yasbd spaCy pipeline component on demand.
-
-Call this to add the ``yasbd`` component factory to spaCy's registry.
-Requires spaCy v3+ to be installed.
-
-Examples
---------
->>> import spacy
->>> from yasbd import register_spacy_component
->>> register_spacy_component()
->>> nlp = spacy.blank("en")
->>> nlp.add_pipe("yasbd", first=True, config={"lang": "en"})
+* [yasbd.utils.trie](#yasbd.utils.trie)
+  * [build\_optimized\_pattern](#yasbd.utils.trie.build_optimized_pattern)
 
 <a id="yasbd.boundary_detector"></a>
 
@@ -415,88 +392,30 @@ class CleanStepError(YasbdError, TypeError)
 
 Raised when a StreamCleaner extra step fails (non-callable or non-str return).
 
-<a id="yasbd.rules"></a>
+<a id="yasbd"></a>
 
-# yasbd.rules
+# yasbd
 
-<a id="yasbd.rules.register_lang_packs"></a>
+<a id="yasbd.register_spacy_component"></a>
 
-#### register\_lang\_packs
-
-```python
-@validate_input
-def register_lang_packs(names: list[str]) -> list[str]
-```
-
-Import and validate external language pack modules.
-
-Each module must expose a ``PROFILES`` list of ``Rules`` subclasses.
-All validated profiles are stored in ``_LANG_PACK_REGISTRY``.
-
-Caution:
-This function imports arbitrary Python modules by name. Only load lang
-packs from sources you trust — an untrusted module can execute
-arbitrary code at import time.
-
-**Arguments**:
-
-- `names` - Module names resolvable from the Python path
-  (e.g. ``["yasbd_indic", "yasbd_legal"]``).
-  
-
-**Returns**:
-
-  List of registered language codes (e.g. ``["xx", "eo"]``).
-  
-
-**Raises**:
-
-- `LangPackError` - If a language pack module cannot be imported.
-
-<a id="yasbd.rules.clear_lang_packs"></a>
-
-#### clear\_lang\_packs
+#### register\_spacy\_component
 
 ```python
-def clear_lang_packs() -> None
+def register_spacy_component()
 ```
 
-Remove all registered language packs and reset the supported-languages cache.
+Register the yasbd spaCy pipeline component on demand.
 
-<a id="yasbd.rules.get_supported_langs"></a>
+Call this to add the ``yasbd`` component factory to spaCy's registry.
+Requires spaCy v3+ to be installed.
 
-#### get\_supported\_langs
-
-```python
-@cache
-def get_supported_langs() -> list[str]
-```
-
-Discover and cache supported language codes.
-
-Returns a sorted list of ``auto`` plus all language codes from
-the built-in rules directory and any registered language packs.
-
-<a id="yasbd.rules.load_rule"></a>
-
-#### load\_rule
-
-```python
-def load_rule(lang: str, *, verbose: bool = False) -> Rules
-```
-
-Import and instantiate the rule module for *lang*.
-
-Checks the language pack registry first; falls back to the built-in rules directory.
-
-**Returns**:
-
-  The instantiated rule object.
-  
-
-**Raises**:
-
-- `UnsupportedLanguageError` - If no rule module exists for *lang*.
+Examples
+--------
+>>> import spacy
+>>> from yasbd import register_spacy_component
+>>> register_spacy_component()
+>>> nlp = spacy.blank("en")
+>>> nlp.add_pipe("yasbd", first=True, config={"lang": "en"})
 
 <a id="yasbd.rules.af"></a>
 
@@ -513,19 +432,6 @@ Checks the language pack registry first; falls back to the built-in rules direct
 <a id="yasbd.rules.base"></a>
 
 # yasbd.rules.base
-
-<a id="yasbd.rules.base.build_abbr_pattern"></a>
-
-#### build\_abbr\_pattern
-
-```python
-def build_abbr_pattern(options: set[str]) -> str
-```
-
-Build an optimised and escaped regex alternation pattern.
-
-Returns a never-match pattern if no valid options exist.
-Ref: https://stackoverflow.com/questions/1723182/a-regex-that-will-never-be-matched-by-anything?
 
 <a id="yasbd.rules.base.CJK"></a>
 
@@ -655,6 +561,89 @@ quote/paren spans, list markers).
 
 # yasbd.rules.id
 
+<a id="yasbd.rules"></a>
+
+# yasbd.rules
+
+<a id="yasbd.rules.register_lang_packs"></a>
+
+#### register\_lang\_packs
+
+```python
+@validate_input
+def register_lang_packs(names: list[str]) -> list[str]
+```
+
+Import and validate external language pack modules.
+
+Each module must expose a ``PROFILES`` list of ``Rules`` subclasses.
+All validated profiles are stored in ``_LANG_PACK_REGISTRY``.
+
+Caution:
+This function imports arbitrary Python modules by name. Only load lang
+packs from sources you trust — an untrusted module can execute
+arbitrary code at import time.
+
+**Arguments**:
+
+- `names` - Module names resolvable from the Python path
+  (e.g. ``["yasbd_indic", "yasbd_legal"]``).
+  
+
+**Returns**:
+
+  List of registered language codes (e.g. ``["xx", "eo"]``).
+  
+
+**Raises**:
+
+- `LangPackError` - If a language pack module cannot be imported.
+
+<a id="yasbd.rules.clear_lang_packs"></a>
+
+#### clear\_lang\_packs
+
+```python
+def clear_lang_packs() -> None
+```
+
+Remove all registered language packs and reset the supported-languages cache.
+
+<a id="yasbd.rules.get_supported_langs"></a>
+
+#### get\_supported\_langs
+
+```python
+@cache
+def get_supported_langs() -> list[str]
+```
+
+Discover and cache supported language codes.
+
+Returns a sorted list of ``auto`` plus all language codes from
+the built-in rules directory and any registered language packs.
+
+<a id="yasbd.rules.load_rule"></a>
+
+#### load\_rule
+
+```python
+def load_rule(lang: str, *, verbose: bool = False) -> Rules
+```
+
+Import and instantiate the rule module for *lang*.
+
+Checks the language pack registry first; falls back to the built-in rules directory.
+
+**Returns**:
+
+  The instantiated rule object.
+  
+
+**Raises**:
+
+- `UnsupportedLanguageError` - If no rule module exists for *lang*.
+
 <a id="yasbd.rules.it"></a>
 
 # yasbd.rules.it
@@ -743,13 +732,21 @@ quote/paren spans, list markers).
 
 # yasbd.rules.zh
 
-<a id="yasbd.utils"></a>
-
-# yasbd.utils
-
 <a id="yasbd.utils.cleaner"></a>
 
 # yasbd.utils.cleaner
+
+<a id="yasbd.utils.cleaner.normalize_newlines"></a>
+
+#### normalize\_newlines
+
+```python
+def normalize_newlines(text: str) -> str
+```
+
+Normalize Windows (
+) and Classic Mac () line endings to Unix (
+).
 
 <a id="yasbd.utils.cleaner.StreamCleaner"></a>
 
@@ -778,8 +775,8 @@ and various regex cleanup rules across paragraphs.
   ['WORD']
   >>> list(StreamCleaner("An hyphe-\nnated sentence"))
   ['An hyphenated sentence']
-  >>> list(StreamCleaner("Don't be naï-\nve"))
-  ["Don't be naïve"]
+  >>> list(StreamCleaner("state-of-the-\nart"))
+  ['state-of-the-art']
   >>> list(StreamCleaner(""))
   []
   >>> StreamCleaner("Hello world", steps_to_skip=["nothing"])
@@ -814,6 +811,7 @@ Implements the iterator protocol. Yields cleaned paragraph strings.
 - `source` - Plain text string or open text stream (e.g., ``StringIO``).
 - `steps_to_skip` - A collection of steps to ignore. All steps will run if not provided.
   choices are:
+  - normalize_newlines
   - fix_mojibake
   - fix_ocr_text
   - unwrap_htmls
@@ -822,6 +820,10 @@ Implements the iterator protocol. Yields cleaned paragraph strings.
 - `extra_steps` - Optional user-defined cleaning functions, run after built-in steps.
   Each function must accept and return ``str``.
 - `verbose` - Enable verbose logging.
+
+<a id="yasbd.utils"></a>
+
+# yasbd.utils
 
 <a id="yasbd.utils.input_validator"></a>
 
@@ -1180,4 +1182,21 @@ def create_yasbd(nlp: Language, name: str, lang: str | None,
 ```
 
 Create a spaCy component powered by yasbd.
+
+<a id="yasbd.utils.trie"></a>
+
+# yasbd.utils.trie
+
+<a id="yasbd.utils.trie.build_optimized_pattern"></a>
+
+#### build\_optimized\_pattern
+
+```python
+def build_optimized_pattern(options: set[str]) -> str
+```
+
+Build an optimised and escaped regex alternation pattern.
+
+Returns a never-match pattern if no valid options exist.
+Ref: https://stackoverflow.com/questions/1723182/a-regex-that-will-never-be-matched-by-anything?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Line ending normalization in default cleaning pipeline** ([#232](https://github.com/speedyk-005/yasbd-lib/issues/232)): Added `normalize_newlines` to `src/yasbd/utils/cleaner.py` and registered it in `DEFAULT_CLEANING_PIPELINE` to normalize `\r\n` and `\r` line endings to `\n`.
+
 ### Changed
 
 - **Trie pattern builder moved to utils and renamed** ([#230](https://github.com/speedyk-005/yasbd-lib/pull/230)): `build_abbr_pattern` moved from `yasbd.rules.base` to a new `yasbd.utils.trie` module and renamed to `build_optimized_pattern`. The old name stays as a backwards-compatible alias, and language rule files now import it from `yasbd.utils.trie`.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@ddelrio1986](https://github.com/ddelrio1986)** | Spelling and grammar fixes in docs |
 | **[@hkJerryLeung](https://github.com/hkJerryLeung)** | French `est` abbreviation fix |
 | **[@hongquan](https://github.com/hongquan)** | `py.typed` marker for PEP 561 compliance |
+| **[@HeaTTap](https://github.com/HeaTTap)** | Line ending normalization in default cleaning pipeline |
 | **[@Jah-yee](https://github.com/Jah-yee)** | Reference abbreviation bracketed citation fix |
 | **[@JheanLL](https://github.com/JheanLL)** | Trie prototype design & Spanish rule contributions |
 | **[@JosephM961](https://github.com/JosephM961)** | Documentation additions and typo fixes |

--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Available built-in steps:
 | `unwrap_htmls` | Removes most HTML markup while preserving visible text. `<b>`, `<i>`, and `<u>` tags are preserved |
 | `normalize_slashes` | Collapses `///` triple slashes |
 | `normalize_spaces` | Collapses multiple spaces into one |
+| `normalize_newlines` | Converts Windows `\\r\\n` and classic Mac `\\r` line endings to Unix `\\n` line endings |
 
 ### CLI ([API](https://github.com/speedyk-005/yasbd-lib/blob/main/API_REFERENCES.md#yasbdcli))
 

--- a/README.md
+++ b/README.md
@@ -225,15 +225,13 @@ detector = BoundaryDetector(lang="en")
 
 # With all options (so far.)
 detector = BoundaryDetector(
-	# ISO 639 code (e.g., en, fr, es, ...). Required.
-	# Use "auto" for automatic detection.
-	# https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+    # ISO 639 code (e.g., en, fr, es, ...). Required.
+    # Use "auto" for automatic detection.
+    # https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
     lang="fr",
-
     # Don't split inside them. (It won't protect block quotes) Defaults to `True`.
     # https://en.wikipedia.org/wiki/Block_quotation
     preserve_quote_and_paren=True,
-
     # Enable verbose logging. Defaults to `False`.
     verbose=True,
 )
@@ -290,16 +288,20 @@ Two detection modes:
 
 ```python
 # absolute mode (default)
-res= list(detector.detect('She turned to him, "This is great." She held the book out to show him.'))
+res = list(
+    detector.detect('She turned to him, "This is great." She held the book out to show him.')
+)
 print(res)
 # [35, 70]
 
 # relative mode with paragraph break
 detector.lang = "es"
-res = list(detector.detect(
-	"El Sr. García llegó ayer. La Sra. López también.\n\nVéase la pág. 55 del libro.",
-	relative=True,
-))
+res = list(
+    detector.detect(
+        "El Sr. García llegó ayer. La Sra. López también.\n\nVéase la pág. 55 del libro.",
+        relative=True,
+    )
+)
 print(res)
 # [25, 48, ParagraphEOF, 27]
 ```
@@ -317,10 +319,12 @@ print(res)
 # ['Hello world.', 'How are you?', 'I am fine.']
 
 # Multi-paragraph with whitespace preserved
-res = list(detector.segment(
-    "First para.\nStill first.\n\nSecond para.\nFinished.",
-    preserve_whitespace=True,
-))
+res = list(
+    detector.segment(
+        "First para.\nStill first.\n\nSecond para.\nFinished.",
+        preserve_whitespace=True,
+    )
+)
 print(res)
 # ['First para.', '\nStill first.', '\n\n', 'Second para.', '\nFinished.']
 ```
@@ -491,7 +495,9 @@ from yasbd.utils.pysbd_adapter import Segmenter
 # Or from yasbd.Pysbd_adapter import Segmenter
 
 seg = Segmenter(language="ja")
-res = seg.segment('田中さんは「準備は完了しました」そう言って部屋を出た。U.S.A.の経済政策は非常に複雑です。')
+res = seg.segment(
+    "田中さんは「準備は完了しました」そう言って部屋を出た。U.S.A.の経済政策は非常に複雑です。"
+)
 print(res)
 # ['田中さんは「準備は完了しました」そう言って部屋を出た。', 'U.S.A.の経済政策は非常に複雑です。']
 ```

--- a/README.md
+++ b/README.md
@@ -414,7 +414,6 @@ Available built-in steps:
 | `fix_mojibake` | Fixes Unicode mojibake via ftfy |
 | `fix_ocr_text` | Repairs OCR artifacts, rejoins hyphenated words, removes page markers |
 | `unwrap_htmls` | Removes most HTML markup while preserving visible text. `<b>`, `<i>`, and `<u>` tags are preserved |
-| `normalize_slashes` | Collapses `///` triple slashes |
 | `normalize_spaces` | Collapses multiple spaces into one |
 | `normalize_newlines` | Converts Windows `\\r\\n` and classic Mac `\\r` line endings to Unix `\\n` line endings |
 

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -97,7 +97,6 @@ NEWLINE_FOLLOWED_BY_PERIOD_FINDER = re.compile(r"\n(?=\.(?=\s))")
 NO_SPACE_BETWEEN_SENTENCES_FINDER = re.compile(r"(?<=\w\.)(?=[A-Z][a-z])")
 
 # https://regex101.com/r/Nw2I67/1
-CONSECUTIVE_FORWARD_SLASH_FINDER = re.compile(r"\/{3}")
 
 NEWLINE_NORMALIZER = re.compile(r"\r\n|\r")
 
@@ -128,15 +127,6 @@ def unwrap_htmls(text: str) -> str:
     return text if "<" not in text else HTML_TAGS_FINDER.sub("", text)
 
 
-def normalize_slashes(text: str) -> str:
-    """Replace triple consecutive forward slashes with empty string.
-
-    Used to clean up artifacts from OCR or text processing that may produce
-    excessive slashes.
-    """
-    return text if "///" not in text else CONSECUTIVE_FORWARD_SLASH_FINDER.sub("", text)
-
-
 def normalize_spaces(text: str) -> str:
     """Replace multiple consecutive spaces with a single space.
 
@@ -150,7 +140,6 @@ DEFAULT_CLEANING_PIPELINE = {
     "fix_mojibake": ftfy.fix_text,
     "fix_ocr_text": _clean_ocr_text,
     "unwrap_htmls": unwrap_htmls,
-    "normalize_slashes": normalize_slashes,
     "normalize_spaces": normalize_spaces,
 }
 
@@ -168,8 +157,6 @@ class StreamCleaner(StreamCleanerStub):
         ['clean text']
         >>> list(StreamCleaner("<b>Hello</b> world", steps_to_skip=["unwrap_htmls"]))
         ['<b>Hello</b> world']
-        >>> list(StreamCleaner("Text with ///slashes"))
-        ['Text with slashes']
         >>> list(StreamCleaner("W\\nO\\nR\\nD"))
         ['WORD']
         >>> list(StreamCleaner("An hyphe-\\nnated sentence"))
@@ -210,7 +197,6 @@ class StreamCleaner(StreamCleanerStub):
                     - fix_mojibake
                     - fix_ocr_text
                     - unwrap_htmls
-                    - normalize_slashes
                     - normalize_spaces
             extra_steps: Optional user-defined cleaning functions, run after built-in steps.
                 Each function must accept and return ``str``.

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -100,6 +100,11 @@ NO_SPACE_BETWEEN_SENTENCES_FINDER = re.compile(r"(?<=\w\.)(?=[A-Z][a-z])")
 CONSECUTIVE_FORWARD_SLASH_FINDER = re.compile(r"\/{3}")
 
 
+def normalize_newlines(text: str) -> str:
+    """Normalize Windows (\r\n) and Classic Mac (\r) line endings to Unix (\n)."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def _clean_ocr_text(text: str) -> str:
     cleaned_text = text.replace("''", '"')
     cleaned_text = NEWLINE_BETWEEN_WORD_CHARS.sub("", cleaned_text)
@@ -113,6 +118,7 @@ def _clean_ocr_text(text: str) -> str:
 
 
 DEFAULT_CLEANING_PIPELINE = {
+    "normalize_newlines": normalize_newlines,
     "fix_mojibake": ftfy.fix_text,
     "fix_ocr_text": _clean_ocr_text,
     "unwrap_htmls": lambda t: t if "<" not in t else HTML_TAGS_FINDER.sub("", t),
@@ -174,6 +180,7 @@ class StreamCleaner(StreamCleanerStub):
             source: Plain text string or open text stream (e.g., ``StringIO``).
             steps_to_skip: A collection of steps to ignore. All steps will run if not provided.
                 choices are:
+                    - normalize_newlines
                     - fix_mojibake
                     - fix_ocr_text
                     - unwrap_htmls

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -119,15 +119,39 @@ def _clean_ocr_text(text: str) -> str:
     return PAGE_FINDER.sub("", cleaned_text)
 
 
+def unwrap_htmls(text: str) -> str:
+    """Remove HTML tags, comments, and declarations from text.
+
+    Uses :class:`HTML_TAGS_FINDER` to strip HTML content while preserving
+    lightweight formatting tags like ``<b>``, ``<i>``, and ``<u>``.
+    """
+    return text if "<" not in text else HTML_TAGS_FINDER.sub("", text)
+
+
+def normalize_slashes(text: str) -> str:
+    """Replace triple consecutive forward slashes with empty string.
+
+    Used to clean up artifacts from OCR or text processing that may produce
+    excessive slashes.
+    """
+    return text if "///" not in text else CONSECUTIVE_FORWARD_SLASH_FINDER.sub("", text)
+
+
+def normalize_spaces(text: str) -> str:
+    """Replace multiple consecutive spaces with a single space.
+
+    Uses :class:`MULTIPLE_SPACES_FINDER` for normalization.
+    """
+    return text if " " not in text else MULTIPLE_SPACES_FINDER.sub(" ", text)
+
+
 DEFAULT_CLEANING_PIPELINE = {
     "normalize_newlines": normalize_newlines,
     "fix_mojibake": ftfy.fix_text,
     "fix_ocr_text": _clean_ocr_text,
-    "unwrap_htmls": lambda t: t if "<" not in t else HTML_TAGS_FINDER.sub("", t),
-    "normalize_slashes": lambda t: (
-        t if "///" not in t else CONSECUTIVE_FORWARD_SLASH_FINDER.sub("", t)
-    ),
-    "normalize_spaces": lambda t: t if " " not in t else MULTIPLE_SPACES_FINDER.sub(" ", t),
+    "unwrap_htmls": unwrap_htmls,
+    "normalize_slashes": normalize_slashes,
+    "normalize_spaces": normalize_spaces,
 }
 
 

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -99,10 +99,12 @@ NO_SPACE_BETWEEN_SENTENCES_FINDER = re.compile(r"(?<=\w\.)(?=[A-Z][a-z])")
 # https://regex101.com/r/Nw2I67/1
 CONSECUTIVE_FORWARD_SLASH_FINDER = re.compile(r"\/{3}")
 
+NEWLINE_NORMALIZER = re.compile(r"\r\n|\r")
+
 
 def normalize_newlines(text: str) -> str:
     """Normalize Windows (\r\n) and Classic Mac (\r) line endings to Unix (\n)."""
-    return text.replace("\r\n", "\n").replace("\r", "\n")
+    return NEWLINE_NORMALIZER.sub("\n", text)
 
 
 def _clean_ocr_text(text: str) -> str:
@@ -130,7 +132,7 @@ DEFAULT_CLEANING_PIPELINE = {
 
 
 class StreamCleaner(StreamCleanerStub):
-    """Normalize and clean noisy text by applying ``ftfy``, HTML sanitization,
+    """Normalize line endings, clean noisy text by applying ``ftfy``, HTML sanitization,
     and various regex cleanup rules across paragraphs.
 
     Examples:

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -4,31 +4,30 @@ from yasbd.utils.cleaner import (
     StreamCleaner,
     normalize_newlines,
     unwrap_htmls,
-    normalize_slashes,
     normalize_spaces,
 )
 
 
 def test_normalize_newlines_windows():
-    """Verify Windows (\r\n) line endings are normalized to \n."""
+    """Verify Windows (\\r\\n) line endings are normalized to \\n."""
     assert normalize_newlines("hello\r\nworld") == "hello\nworld"
     assert normalize_newlines("line1\r\nline2\r\nline3") == "line1\nline2\nline3"
 
 
 def test_normalize_newlines_mac():
-    """Verify Classic Mac (\r) line endings are normalized to \n."""
+    """Verify Classic Mac (\\r) line endings are normalized to \\n."""
     assert normalize_newlines("hello\rworld") == "hello\nworld"
     assert normalize_newlines("line1\rline2\rline3") == "line1\nline2\nline3"
 
 
 def test_normalize_newlines_unix():
-    """Verify Unix (\n) line endings remain unchanged."""
+    """Verify Unix (\\n) line endings remain unchanged."""
     assert normalize_newlines("hello\nworld") == "hello\nworld"
     assert normalize_newlines("line1\nline2\nline3") == "line1\nline2\nline3"
 
 
 def test_normalize_newlines_mixed():
-    """Verify mixed line endings are all normalized to \n."""
+    """Verify mixed line endings are all normalized to \\n."""
     assert (
         normalize_newlines("line1\r\nline2\rline3\nline4")
         == "line1\nline2\nline3\nline4"
@@ -65,25 +64,6 @@ def test_unwrap_htmls_guarded_paths():
     assert unwrap_htmls("<p>paragraph</p>") == "paragraph"
 
 
-def test_normalize_slashes_replaces_triple_slashes():
-    """Verify normalize_slashes replaces triple consecutive forward slashes with empty string."""
-    assert normalize_slashes("text///with///slashes") == "textwithslashes"
-    assert normalize_slashes("text///") == "text"
-    assert normalize_slashes("text") == "text"
-    assert normalize_slashes("///") == ""
-    assert normalize_slashes("a///b///c") == "abc"
-
-
-def test_normalize_slashes_guarded_and_unguarded():
-    """Verify normalize_slashes handles both guarded and unguarded paths."""
-    # Guarded: no triple slashes
-    assert normalize_slashes("a/b/c") == "a/b/c"
-    assert normalize_slashes("no slashes") == "no slashes"
-    # Unguarded: has triple slashes
-    assert normalize_slashes("a///b") == "ab"
-    assert normalize_slashes("start///end") == "startend"
-
-
 def test_normalize_spaces_replaces_multiple_spaces():
     """Verify normalize_spaces replaces multiple consecutive spaces."""
     assert normalize_spaces("hello  world") == "hello world"
@@ -105,6 +85,21 @@ def test_normalize_spaces_guarded_and_unguarded():
     assert normalize_spaces("a   b") == "a b"
 
 
+def test_stream_cleaner_preserves_consecutive_slashes():
+    """Verify StreamCleaner does not delete /// slashes or glue words together."""
+    text1 = "a///b"
+    assert list(StreamCleaner(text1)) == ["a///b"]
+
+    text2 = "Text with ///slashes"
+    assert list(StreamCleaner(text2)) == ["Text with ///slashes"]
+
+    url_text = "file:///C:/Users/test/doc.txt"
+    assert list(StreamCleaner(url_text)) == ["file:///C:/Users/test/doc.txt"]
+
+    rust_doc = "/// This is a Rust doc comment"
+    assert list(StreamCleaner(rust_doc)) == ["/// This is a Rust doc comment"]
+
+
 def test_cleaner_pipeline_integration():
     """Verify the full pipeline works with the new named functions."""
     # Test normalize_newlines with punctuation (not between word chars)
@@ -115,15 +110,11 @@ def test_cleaner_pipeline_integration():
     cleaner = StreamCleaner("<p>Hello</p>")
     assert list(cleaner) == ["Hello"]
 
-    # Test normalize_slashes
-    cleaner = StreamCleaner("test///value")
-    assert list(cleaner) == ["testvalue"]
-
     # Test normalize_spaces
     cleaner = StreamCleaner("hello  world")
     assert list(cleaner) == ["hello world"]
 
-    # Test combined: HTML with spaces and slashes
+    # Test combined: HTML with spaces (slashes preserved)
     cleaner = StreamCleaner("  <p>test  ///  value</p>  ")
     result = list(cleaner)[0]
-    assert result == "test value"
+    assert result == "test /// value"

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -1,44 +1,38 @@
 import io
 
-from yasbd.utils.cleaner import StreamCleaner, normalize_newlines
+from yasbd.utils.cleaner import (
+    StreamCleaner,
+    normalize_newlines,
+    unwrap_htmls,
+    normalize_slashes,
+    normalize_spaces,
+)
 
 
 def test_normalize_newlines_windows():
-    """Verify Windows (\\r\\n) line endings are normalized to \\n."""
+    """Verify Windows (\r\n) line endings are normalized to \n."""
     assert normalize_newlines("hello\r\nworld") == "hello\nworld"
     assert normalize_newlines("line1\r\nline2\r\nline3") == "line1\nline2\nline3"
 
 
 def test_normalize_newlines_mac():
-    """Verify Classic Mac (\\r) line endings are normalized to \\n."""
+    """Verify Classic Mac (\r) line endings are normalized to \n."""
     assert normalize_newlines("hello\rworld") == "hello\nworld"
     assert normalize_newlines("line1\rline2\rline3") == "line1\nline2\nline3"
 
 
 def test_normalize_newlines_unix():
-    """Verify Unix (\\n) line endings remain unchanged."""
+    """Verify Unix (\n) line endings remain unchanged."""
     assert normalize_newlines("hello\nworld") == "hello\nworld"
     assert normalize_newlines("line1\nline2\nline3") == "line1\nline2\nline3"
 
 
 def test_normalize_newlines_mixed():
-    """Verify mixed line endings are all normalized to \\n."""
+    """Verify mixed line endings are all normalized to \n."""
     assert (
         normalize_newlines("line1\r\nline2\rline3\nline4")
         == "line1\nline2\nline3\nline4"
     )
-
-
-def test_stream_cleaner_with_different_line_endings():
-    """Verify StreamCleaner normalizes line endings across inputs."""
-    windows_cleaner = StreamCleaner("Hello.\r\nWorld")
-    assert list(windows_cleaner) == ["Hello.\nWorld"]
-
-    mac_cleaner = StreamCleaner("Hello.\rWorld")
-    assert list(mac_cleaner) == ["Hello.\nWorld"]
-
-    unix_cleaner = StreamCleaner("Hello.\nWorld")
-    assert list(unix_cleaner) == ["Hello.\nWorld"]
 
 
 def test_stream_cleaner_skip_normalize_newlines():
@@ -48,3 +42,88 @@ def test_stream_cleaner_skip_normalize_newlines():
         steps_to_skip=["normalize_newlines", "fix_mojibake", "fix_ocr_text"],
     )
     assert list(cleaner) == ["hello.\rworld"]
+
+
+def test_unwrap_htmls_removes_html_tags():
+    """Verify unwrap_htmls removes HTML tags and comments."""
+    assert unwrap_htmls("<p>Hello</p>") == "Hello"
+    assert unwrap_htmls("<!-- comment -->Hello") == "Hello"
+    # <b>, <i>, <u> are preserved as lightweight formatting
+    assert unwrap_htmls("Hello <b>world</b>!") == "Hello <b>world</b>!"
+    assert unwrap_htmls("Hello <i>world</i>!") == "Hello <i>world</i>!"
+    assert unwrap_htmls("Hello <u>world</u>!") == "Hello <u>world</u>!"
+    assert unwrap_htmls("Hello world") == "Hello world"
+    assert unwrap_htmls("") == ""
+    assert unwrap_htmls("<script>alert('xss')</script>") == ""
+
+
+def test_unwrap_htmls_guarded_paths():
+    """Verify unwrap_htmls handles both guarded and unguarded paths."""
+    # Guarded path: text without '<' returns unchanged
+    assert unwrap_htmls("no html here") == "no html here"
+    # Unguarded path: text with '<' gets processed
+    assert unwrap_htmls("<p>paragraph</p>") == "paragraph"
+
+
+def test_normalize_slashes_replaces_triple_slashes():
+    """Verify normalize_slashes replaces triple consecutive forward slashes with empty string."""
+    assert normalize_slashes("text///with///slashes") == "textwithslashes"
+    assert normalize_slashes("text///") == "text"
+    assert normalize_slashes("text") == "text"
+    assert normalize_slashes("///") == ""
+    assert normalize_slashes("a///b///c") == "abc"
+
+
+def test_normalize_slashes_guarded_and_unguarded():
+    """Verify normalize_slashes handles both guarded and unguarded paths."""
+    # Guarded: no triple slashes
+    assert normalize_slashes("a/b/c") == "a/b/c"
+    assert normalize_slashes("no slashes") == "no slashes"
+    # Unguarded: has triple slashes
+    assert normalize_slashes("a///b") == "ab"
+    assert normalize_slashes("start///end") == "startend"
+
+
+def test_normalize_spaces_replaces_multiple_spaces():
+    """Verify normalize_spaces replaces multiple consecutive spaces."""
+    assert normalize_spaces("hello  world") == "hello world"
+    assert normalize_spaces("hello   world") == "hello world"
+    assert normalize_spaces("hello  world  test") == "hello world test"
+    assert normalize_spaces("  leading") == " leading"
+    assert normalize_spaces("trailing  ") == "trailing "
+    assert normalize_spaces("") == ""
+    assert normalize_spaces(" ") == " "
+
+
+def test_normalize_spaces_guarded_and_unguarded():
+    """Verify normalize_spaces handles both guarded and unguarded paths."""
+    # Guarded: no multiple consecutive spaces
+    assert normalize_spaces("hello world") == "hello world"
+    assert normalize_spaces("single space") == "single space"
+    # Unguarded: has multiple consecutive spaces
+    assert normalize_spaces("hello  world") == "hello world"
+    assert normalize_spaces("a   b") == "a b"
+
+
+def test_cleaner_pipeline_integration():
+    """Verify the full pipeline works with the new named functions."""
+    # Test normalize_newlines with punctuation (not between word chars)
+    cleaner = StreamCleaner("Hello.\r\nWorld")
+    assert list(cleaner) == ["Hello.\nWorld"]
+
+    # Test unwrap_htmls
+    cleaner = StreamCleaner("<p>Hello</p>")
+    assert list(cleaner) == ["Hello"]
+
+    # Test normalize_slashes
+    cleaner = StreamCleaner("test///value")
+    assert list(cleaner) == ["testvalue"]
+
+    # Test normalize_spaces
+    cleaner = StreamCleaner("hello  world")
+    assert list(cleaner) == ["hello world"]
+
+    # Test combined: HTML with spaces and slashes
+    cleaner = StreamCleaner("  <p>test  ///  value</p>  ")
+    result = list(cleaner)[0]
+    assert result == "test value"

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -1,0 +1,50 @@
+import io
+
+from yasbd.utils.cleaner import StreamCleaner, normalize_newlines
+
+
+def test_normalize_newlines_windows():
+    """Verify Windows (\\r\\n) line endings are normalized to \\n."""
+    assert normalize_newlines("hello\r\nworld") == "hello\nworld"
+    assert normalize_newlines("line1\r\nline2\r\nline3") == "line1\nline2\nline3"
+
+
+def test_normalize_newlines_mac():
+    """Verify Classic Mac (\\r) line endings are normalized to \\n."""
+    assert normalize_newlines("hello\rworld") == "hello\nworld"
+    assert normalize_newlines("line1\rline2\rline3") == "line1\nline2\nline3"
+
+
+def test_normalize_newlines_unix():
+    """Verify Unix (\\n) line endings remain unchanged."""
+    assert normalize_newlines("hello\nworld") == "hello\nworld"
+    assert normalize_newlines("line1\nline2\nline3") == "line1\nline2\nline3"
+
+
+def test_normalize_newlines_mixed():
+    """Verify mixed line endings are all normalized to \\n."""
+    assert (
+        normalize_newlines("line1\r\nline2\rline3\nline4")
+        == "line1\nline2\nline3\nline4"
+    )
+
+
+def test_stream_cleaner_with_different_line_endings():
+    """Verify StreamCleaner normalizes line endings across inputs."""
+    windows_cleaner = StreamCleaner("Hello.\r\nWorld")
+    assert list(windows_cleaner) == ["Hello.\nWorld"]
+
+    mac_cleaner = StreamCleaner("Hello.\rWorld")
+    assert list(mac_cleaner) == ["Hello.\nWorld"]
+
+    unix_cleaner = StreamCleaner("Hello.\nWorld")
+    assert list(unix_cleaner) == ["Hello.\nWorld"]
+
+
+def test_stream_cleaner_skip_normalize_newlines():
+    """Verify normalize_newlines step can be skipped via steps_to_skip."""
+    cleaner = StreamCleaner(
+        io.StringIO("hello.\rworld", newline=""),
+        steps_to_skip=["normalize_newlines", "fix_mojibake", "fix_ocr_text"],
+    )
+    assert list(cleaner) == ["hello.\rworld"]


### PR DESCRIPTION
## Objective

Remove the destructive `normalize_slashes` step from `StreamCleaner` which was deleting 3+ consecutive forward slashes (\/\/\/) and silently gluing adjacent words together (e.g., `a///b` -> `ab`). This corrupted legitimate text in doc comments (Rust/C# `///`), `file:///` URLs, and XML doc markers.

## Changes

- Removed `CONSECUTIVE_FORWARD_SLASH_FINDER` regex and `normalize_slashes` entry from `DEFAULT_CLEANING_PIPELINE` in `src/yasbd/utils/cleaner.py`.
- Updated `README.md` (removed 'repeated slashes' mention and `normalize_slashes` row in cleaning steps table).
- Regenerated `API_REFERENCES.md`.
- Added unit tests in `tests/test_cleaner.py` verifying that `///` slashes are preserved intact and removed destructive slash normalization tests.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #241