### PR TITLE
Expand StreamCleaner SUFFIXES to rejoin hyphenated words across line breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Expanded SUFFIXES in hyphenated word finder** ([#249](https://github.com/speedyk-005/yasbd-lib/pull/249)): Added common Latin inflectional and derivational suffixes to the `SUFFIXES` set used by `HYPHENATED_WORD_FINDER`, so wrap-around line breaks like `work-\ning` join correctly to `working`.
 - **Line ending normalization in default cleaning pipeline** ([#232](https://github.com/speedyk-005/yasbd-lib/issues/232)): Added `normalize_newlines` to `src/yasbd/utils/cleaner.py` and registered it in `DEFAULT_CLEANING_PIPELINE` to normalize `\r\n` and `\r` line endings to `\n`.
 - **Post-processing hook on BoundaryDetector** ([#234](https://github.com/speedyk-005/yasbd-lib/pull/234)): `BoundaryDetector` now accepts a `hook` callback that runs per paragraph after the language rules apply. It receives a dict with `text`, `lang`, `boundaries` and `paragraph_index` keys and can add or remove sentence boundaries in place. A new `HookError` is raised if the hook fails or leaves invalid boundaries. This replaces monkey-patching rule internals for custom boundary logic (e.g. OpenMed's `_split_yasbd_chinese_semicolons` hack).
 

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -21,7 +21,10 @@ PREFIXES = {
     "pseudo", "quasi", "re", "retro", "semi", "sub", "super", "supra",
     "tele", "trans", "tri", "ultra", "un", "uni", "phe", "ani",
 }
-SUFFIXES = {"sis", "tion", "ry", "nal", "mal", "no", "té"}
+SUFFIXES = {
+    "able", "ed", "ing", "ive", "ly", "ment", "ness", "ous", "tion",
+    "ve", "sis", "ry", "nal", "mal", "no", "té",
+}
 # fmt: on
 
 # https://regex101.com/r/dL1zCM/1


### PR DESCRIPTION
## Objective

`HYPHENATED_WORD_FINDER` only joins wrap-around line breaks when the part after the hyphen matches a known suffix, and the `SUFFIXES` set was missing common English inflectional and derivational suffixes. Legitimate breaks like `work-\ning` stayed `work-ing` instead of rejoining to `working`.

## Changes

- Expanded `SUFFIXES` in `src/yasbd/utils/cleaner.py` with common English suffixes: `able`, `ed`, `ing`, `ive`, `ly`, `ment`, `ness`, `ous`, `tion`, `ve`.
- No regex changes: the set is compiled through `build_optimized_pattern`, so extending the set is all that was needed.
- Wrap-around joins now work: `work-\ning` becomes `working`, `quick-\nly` becomes `quickly`, `develop-\nment` becomes `development`.

### Types of change

- [x] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass (99 passed, 2 skipped).
- [x] I ran `ruff format . && ruff check --fix .`.
- [ ] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #244
