### PR TITLE
Preserve word boundaries across line breaks in StreamCleaner

### DIFF
--- a/API_REFERENCES.md
+++ b/API_REFERENCES.md
@@ -834,7 +834,9 @@ and various regex cleanup rules across paragraphs.
   >>> list(StreamCleaner("<b>Hello</b> world", steps_to_skip=["unwrap_htmls"]))
   ['<b>Hello</b> world']
   >>> list(StreamCleaner("W\nO\nR\nD"))
-  ['WORD']
+  ['W O R D']
+  >>> list(StreamCleaner("I am a good\nman"))
+  ['I am a good man']
   >>> list(StreamCleaner("An hyphe-\nnated sentence"))
   ['An hyphenated sentence']
   >>> list(StreamCleaner("state-of-the-\nart"))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Words concatenated across line breaks** ([#254](https://github.com/speedyk-005/yasbd-lib/issues/254)): StreamCleaner now replaces newlines between word characters with a space, preserving word boundaries in OCR text.
+- **Words concatenated across line breaks** ([#255](https://github.com/speedyk-005/yasbd-lib/pull/255)): StreamCleaner now replaces newlines between word characters with a space, preserving word boundaries in OCR text.
 
 ## [0.14.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- **Words concatenated across line breaks** ([#254](https://github.com/speedyk-005/yasbd-lib/issues/254)): StreamCleaner now replaces newlines between word characters with a space, preserving word boundaries in OCR text.
+
 ## [0.14.0] - 2026-08-09
 
 ### Added

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@1cbyc](https://github.com/1cbyc)** | Coordinate direction abbreviation fix |
 | **[@AshSgDe29071999](https://github.com/AshSgDe29071999)** | Combined same-module imports in `__init__.py`; named cleaning-pipeline helpers for testability |
 | **[@cnaples79](https://github.com/cnaples79)** | Missing comma in set literals fix |
+| **[@ColumbusLabs](https://github.com/ColumbusLabs)** | Preserve word boundaries across StreamCleaner line breaks |
 | **[@ddelrio1986](https://github.com/ddelrio1986)** | Spelling and grammar fixes in docs |
 | **[@HeaTTap](https://github.com/HeaTTap)** | Line ending normalization in default cleaning pipeline; removed destructive slash normalization from StreamCleaner |
 | **[@hkJerryLeung](https://github.com/hkJerryLeung)** | French `est` abbreviation fix |

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Common cleanup operations include:
 - Removing HTML markup (lightweight preprocessor, not a full HTML parser)
 - Normalizing whitespace
 - Rejoining hyphenated words split across lines
-- Merging vertically stacked characters
+- Preserving word boundaries across single line breaks
 
 **Skip** built-in steps you don't want:
 

--- a/src/yasbd/utils/cleaner.py
+++ b/src/yasbd/utils/cleaner.py
@@ -111,7 +111,7 @@ def normalize_newlines(text: str) -> str:
 
 def _clean_ocr_text(text: str) -> str:
     cleaned_text = text.replace("''", '"')
-    cleaned_text = NEWLINE_BETWEEN_WORD_CHARS.sub("", cleaned_text)
+    cleaned_text = NEWLINE_BETWEEN_WORD_CHARS.sub(" ", cleaned_text)
     cleaned_text = NEWLINE_FOLLOWED_BY_PERIOD_FINDER.sub("", cleaned_text)
     cleaned_text = HEADING_OR_LIST_FINDER.sub(" ", cleaned_text)
     cleaned_text = NO_SPACE_BETWEEN_SENTENCES_FINDER.sub(" ", cleaned_text)
@@ -154,7 +154,9 @@ class StreamCleaner(StreamCleanerStub):
         >>> list(StreamCleaner("<b>Hello</b> world", steps_to_skip=["unwrap_htmls"]))
         ['<b>Hello</b> world']
         >>> list(StreamCleaner("W\\nO\\nR\\nD"))
-        ['WORD']
+        ['W O R D']
+        >>> list(StreamCleaner("I am a good\\nman"))
+        ['I am a good man']
         >>> list(StreamCleaner("An hyphe-\\nnated sentence"))
         ['An hyphenated sentence']
         >>> list(StreamCleaner("state-of-the-\\nart"))


### PR DESCRIPTION
## Objective

Prevent `StreamCleaner` from concatenating adjacent words when OCR text wraps at a line break.

## Changes

- Replace newlines between word characters with a space instead of deleting them.
- Add the issue reproducer to the `StreamCleaner` doctests.
- Update the generated API reference, README behavior list, changelog, and contributor record.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [x] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass (108 passed, 2 skipped, 1,025 subtests passed).
- [x] I ran Ruff format checks on the changed Python source and `ruff check` across the repository.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #254
