### PR TITLE
Make auto language detection opt-in to reduce default dependency size

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        uv pip install -e ".[dev]" spacy langcodes
+        uv pip install -e ".[dev]" spacy langcodes py3langid
     - name: Test with Pytest
       run: |
         uv run pytest -v --tb=short

--- a/API_REFERENCES.md
+++ b/API_REFERENCES.md
@@ -1007,6 +1007,7 @@ selected candidates.
 
 **Raises**:
 
+- `ImportError` - If ``py3langid`` is not installed.
 - `ValueError` - If the detector returns no language scores.
 
 <a id="yasbd.utils.logger"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- **Language auto-detection is now opt-in** ([#256](https://github.com/speedyk-005/yasbd-lib/pull/256)): `py3langid` is no longer a core dependency. It is imported lazily inside `classify_language()`, so `import yasbd` no longer pulls in numpy for users who never use `lang="auto"`. If you need auto-detection, install it separately with `pip install py3langid`; otherwise you get a clear error.
+
 ## [0.14.0] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Language auto-detection is now opt-in** ([#256](https://github.com/speedyk-005/yasbd-lib/pull/256)): `py3langid` is no longer a core dependency. It is imported lazily inside `classify_language()`, so `import yasbd` no longer pulls in numpy for users who never use `lang="auto"`. If you need auto-detection, install it separately with `pip install py3langid`; otherwise you get a clear error.
+- **Language auto-detection is now opt-in** ([#256](https://github.com/speedyk-005/yasbd-lib/pull/256)): `py3langid` is no longer a core dependency. It is imported lazily inside `classify_language()`, so `import yasbd` no longer pulls in numpy for users who never use `lang="auto"`. It must be installed separately.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Each language rule loads once into a 5-slot cache. Once loaded, a language stays
 >
 > Pass `lang="auto"` if you want the system to figure out the language for you.
 > I wouldn't lean on it too hard though — it's a bit slower, and short phrases can throw it off sometimes.
+>
+> Requires the `py3langid` package. Install it separately: `pip install py3langid`
 
 ### Core Methods
 The two primary APIs are detect() and segment().

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "regex>=2024.11.6",
   "ftfy>=6.2.0,<7.0",
   "retrie>=0.3.0,<1.0",
-  "py3langid>=0.2.2,<1.0",
   "radicli>=0.0.25,<1.0",
   "beartype>=0.22.6,<1.0",
 ]

--- a/src/yasbd/utils/language_classifier.py
+++ b/src/yasbd/utils/language_classifier.py
@@ -1,8 +1,6 @@
 import math
 from functools import lru_cache
 
-import py3langid as langid
-
 from yasbd.rules import get_supported_langs
 
 PREFERRED = get_supported_langs()
@@ -46,8 +44,17 @@ def classify_language(text: str) -> tuple[str, float]:
         True
 
     Raises:
+        ImportError: If ``py3langid`` is not installed.
         ValueError: If the detector returns no language scores.
     """
+    try:
+        import py3langid as langid
+    except ImportError:  # pragma: no cover
+        raise ImportError(
+            "py3langid is required for language auto-detection. "
+            "Install it with: pip install py3langid"
+        ) from None
+
     ranks = langid.rank(text)
     _, top_score = ranks[0]
 


### PR DESCRIPTION
## Objective

`import yasbd` currently drags in `py3langid`, which drags in numpy. That's roughly 35-70MB of installed dependencies just so `lang="auto"` can work - and most users never use auto mode. This PR makes auto-detection opt-in, so the common fixed-language path stays lean.

## Changes

- `language_classifier.py`: `py3langid` is now imported inside `classify_language()` instead of at module load. The function was already `lru_cache`d, so nothing gets slower.
- `language_classifier.py`: if `py3langid` isn't installed, `classify_language()` raises an `ImportError` that tells you how to fix it.
- `pyproject.toml`: `py3langid` removed from the core `dependencies`.

`boundary_detector.py` needed no changes. It only touches the classifier on the `lang="auto"` paths anyway, and both now surface that same clear error.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass (108 passed, 2 skipped).
- [x] I ran `ruff format . && ruff check --fix .`.
- [ ] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

Manually checked:
- `import yasbd` leaves both `numpy` and `py3langid` out of `sys.modules`.
- `BoundaryDetector(lang="auto")` without `py3langid` installed raises the new, actionable `ImportError`.

## Related Issues

- Fixes #252