### PR TITLE
Fix geopolitical abbreviations before org/gov nouns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Language auto-detection is now opt-in** ([#256](https://github.com/speedyk-005/yasbd-lib/pull/256)): `py3langid` is no longer a core dependency. It is imported lazily inside `classify_language()`, so `import yasbd` no longer pulls in numpy for users who never use `lang="auto"`. It must be installed separately.
+- **Language auto-detection is now opt-in** ([#256](https://github.com/speedyk-005/yasbd-lib/pull/256)): `py3langid` is no longer a core dependency. It is imported lazily inside `classify_language()`, so `import yasbd` no longer pulls in numpy for users who never use `lang="auto"`. It must be installed separately.[span_0](start_span)[span_0](end_span)
 
 ### Fixed
 
-- **Words concatenated across line breaks** ([#255](https://github.com/speedyk-005/yasbd-lib/pull/255)): StreamCleaner now replaces newlines between word characters with a space, preserving word boundaries in OCR text.
+- **Words concatenated across line breaks** ([#255](https://github.com/speedyk-005/yasbd-lib/pull/255)): StreamCleaner now replaces newlines between word characters with a space, preserving word boundaries in OCR text.[span_1](start_span)[span_1](end_span)
+- **False sentence splits after geopolitical abbreviations** ([#257](https://github.com/speedyk-005/yasbd-lib/pull/257)): Expanded `ORG_PROPER_NOUNS` in English rules to prevent premature sentence breaks when abbreviations like `U.S.` or `U.K.` precede common government and organizational nouns (e.g., `Government`, `Department`, `Persons`). Fixes [#253](https://github.com/speedyk-005/yasbd-lib/issues/253).
 
 ---
 

--- a/src/yasbd/rules/en.py
+++ b/src/yasbd/rules/en.py
@@ -68,6 +68,12 @@ class EnRules(Rules):
         "Cabinet", "Commons", "Congress",
         "House of Representatives", "Parliament", "Senate",
         "Supreme Court",
+
+        # Government bodies and agencies
+        "Government", "Persons", "Department", "Agency", "Customs",
+        "Embassy", "Consulate", "Administration", "Commission",
+        "Authority", "Bureau", "Office", "Service", "Committee",
+        "Board", "Council", "Institute",
     }
 
     DATE_WORDS = {

--- a/tests/test_data/english.py
+++ b/tests/test_data/english.py
@@ -8,7 +8,7 @@ TEST_DATA = [
     "Her email is Jane.Doe@example.com.| I sent her an email.",
     "The site is: https://www.example.50.com/new-site/awesome_content.html.| Please check it out.",
 
-    # Abbreviations
+    # -- Abbreviations --
     "My name is Jonas E. Smith.",
     "A. B. Smith graduated from Harvard.| He then worked from IBM Corp.",
     "Please turn to p. 55.",
@@ -19,9 +19,6 @@ TEST_DATA = [
     "St. Michael's Church is on 5th st. near the light.",
     "That is JFK Jr.'s book.",
     "I visited the U.S.A. last year.",
-    "I live in the E.U.| How about you?",
-    "He serves in the U.S. Army.",
-    "The U.S. government passed a new law.",
     "I have lived in the U.S. for 20 years.",
     "She has $100.00 in her bag.",
     "She has $100.00.| It is in her bag.",
@@ -40,6 +37,13 @@ TEST_DATA = [
     "We make a good team, you and I.| Did you see Albert I. Jones yesterday?",
     "He left the bank at 6 P.M.| Mr. Smith then went to the store.",
     "The little boy turned off the TV.| He then closed the door.",
+    # Geopolitical abbrv + Captitalized word (fix for #253)
+    "This role requires U.S. Government security clearance.",
+    "This job is open to U.S. Persons only per export law.",
+    "The contract applies to U.K. Government employees.",
+    "I live in the E.U.| How about you?",
+    "He serves in the U.S. Army.",
+    "The U.S. government passed a new law.",
 
     # structural headings (fix for #36)
     "Chapter 1. The Beginning.| It was dark and quiet in the room. | Nothing moved.",


### PR DESCRIPTION
## Objective

Fix false sentence breaks caused by geopolitical abbreviations (`U.S.`, `U.K.`, ...) occurring before common capitalized organization and government nouns.

## Changes

- Expanded `ORG_PROPER_NOUNS` in `src/yasbd/rules/en.py` to include common government, administrative, and institutional nouns (e.g., `Government`, `Department`, `Agency`, `Persons`).
- Added regression tests in `tests/test_data/en.py` covering multi-word geopolitical noun contexts while ensuring standard sentence boundaries remain intact.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #253