### PR TITLE
Separate type and bounds validation in _run_hook

### DIFF
--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -42,6 +42,17 @@ _MIN_CONFIDENCE = 0.8
 # Maximum number of rule instances to keep in cache
 _MAX_CACHED_RULES = 5
 
+# Offending offsets listed in a HookError before eliding the rest. A hook can
+# hand back thousands of values; the first few identify the mistake.
+_MAX_REPORTED_OFFSETS = 5
+
+
+def _describe_offsets(offsets: list[object]) -> str:
+    """Render offending offsets for a HookError, eliding a long tail."""
+    shown = ", ".join(repr(pos) for pos in offsets[:_MAX_REPORTED_OFFSETS])
+    extra = len(offsets) - _MAX_REPORTED_OFFSETS
+    return f"{shown} (and {extra} more)" if extra > 0 else shown
+
 
 class BoundaryDetector:
     @validate_input
@@ -162,12 +173,26 @@ class BoundaryDetector:
             raise HookError(f"post-processing hook raised an error: {exc!r}") from exc
 
         result = ctx["boundaries"]
-        if not isinstance(result, list) or not all(
-            isinstance(pos, int) and 0 <= pos <= len(text) for pos in result
-        ):
+        # Type and bounds are checked separately: a hook that returned a string
+        # and one that returned an offset past the paragraph end are different
+        # mistakes, and the second is far easier to fix when the offending
+        # values are named.
+        if not isinstance(result, list):
             raise HookError(
-                "post-processing hook must leave 'boundaries' as a list of "
-                "int offsets within the paragraph"
+                "post-processing hook must leave 'boundaries' as a list, got "
+                f"{type(result).__name__}"
+            )
+        non_ints = [pos for pos in result if not isinstance(pos, int)]
+        if non_ints:
+            raise HookError(
+                "post-processing hook must leave 'boundaries' as a list of int "
+                f"offsets; got {_describe_offsets(non_ints)}"
+            )
+        out_of_bounds = [pos for pos in result if not 0 <= pos <= len(text)]
+        if out_of_bounds:
+            raise HookError(
+                "post-processing hook returned offset(s) outside the paragraph "
+                f"bounds [0, {len(text)}]: {_describe_offsets(out_of_bounds)}"
             )
         if 0 not in result or len(text) not in result:
             raise HookError(

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -7,6 +7,7 @@ import pytest
 from tests import ALL_TEST_DATA
 from yasbd import (
     BoundaryDetector,
+    HookError,
     InvalidInputError,
     ParagraphEOF,
     UnsupportedLanguageError,
@@ -233,3 +234,72 @@ def test_post_processing_hook():
     detector = BoundaryDetector(lang="en", hook=tweak)
     assert list(detector.segment("Hi. There world.")) == ["Hi. There", "world."]
     assert list(detector.detect("Hi. There world.")) == [10, 16]
+
+
+def _detect_with_hook(hook, text="Hi. There world."):
+    """Run a hook that is expected to fail validation, and return the error."""
+    detector = BoundaryDetector(lang="en", hook=hook)
+    with pytest.raises(HookError) as excinfo:
+        list(detector.detect(text))
+    return str(excinfo.value)
+
+
+def test_hook_returning_a_non_list_names_the_type():
+    def bad(ctx):
+        ctx["boundaries"] = "0,16"
+
+    message = _detect_with_hook(bad)
+    assert "must leave 'boundaries' as a list" in message
+    assert "got str" in message
+
+
+def test_hook_returning_non_int_offsets_names_them():
+    def bad(ctx):
+        ctx["boundaries"] = [0, "8", 16.0]
+
+    message = _detect_with_hook(bad)
+    assert "list of int offsets" in message
+    assert "'8'" in message
+    assert "16.0" in message
+    # The type complaint must not be confused with the bounds complaint.
+    assert "outside the paragraph" not in message
+
+
+def test_hook_returning_out_of_bounds_offsets_names_them():
+    def bad(ctx):
+        ctx["boundaries"] = [-1, 500]
+
+    message = _detect_with_hook(bad)
+    assert "outside the paragraph bounds [0, 16]" in message
+    assert "-1" in message
+    assert "500" in message
+    assert "list of int offsets" not in message
+
+
+def test_hook_error_reports_only_the_offending_offsets():
+    """A valid offset alongside a bad one must not be blamed."""
+
+    def bad(ctx):
+        ctx["boundaries"] = [0, 3, 16, 99]
+
+    message = _detect_with_hook(bad)
+    # The listed offsets are exactly the offenders, not the whole boundary list.
+    assert message.endswith(": 99")
+
+
+def test_hook_error_elides_a_long_tail_of_offsets():
+    def bad(ctx):
+        ctx["boundaries"] = [0, 16, *range(100, 120)]
+
+    message = _detect_with_hook(bad)
+    assert "and 15 more" in message
+
+
+def test_hook_offset_at_the_paragraph_end_is_in_bounds():
+    """len(text) is a valid boundary - the check is inclusive at both ends."""
+
+    def keep(ctx):
+        ctx["boundaries"] = [0, 16]
+
+    detector = BoundaryDetector(lang="en", hook=keep)
+    assert list(detector.detect("Hi. There world.")) == [16]


### PR DESCRIPTION
Closes #259.

`_run_hook` validated the hook result with one composite condition, so a hook returning a string, one returning floats, and one returning an out-of-range offset all raised the identical generic `HookError`.

## What changed

Three checks, each with its own message:

| Mistake | Message |
|---|---|
| not a list | `must leave 'boundaries' as a list, got str` |
| non-int elements | `must leave 'boundaries' as a list of int offsets; got '8', 16.0` |
| out of range | `returned offset(s) outside the paragraph bounds [0, 16]: -1, 500` |

Two details beyond the split, both aimed at the same debugging problem:

- **Only the offenders are listed**, not the whole boundary list. `[0, 3, 16, 99]` reports `99`, so the one bad value is obvious rather than buried.
- **`_describe_offsets` elides past five values.** A hook can hand back thousands of offsets; the first few identify the mistake and the rest would bury it.

Behaviour is otherwise unchanged — the same inputs raise `HookError`, and the "must keep the paragraph start and end" check below is untouched. I deliberately left `isinstance(pos, int)` as-is rather than tightening it (it accepts `bool`), so nothing that was accepted before is rejected now.

## Tests

6 added to `tests/test_boundary_detector.py`, via a small `_detect_with_hook` helper that returns the message:

- each of the three branches names the right thing
- the type message and the bounds message **don't bleed into each other** (a bounds error must not say "list of int offsets", and vice versa)
- only the offending offsets are listed
- the long-tail elision
- `len(text)` is still a valid in-bounds offset — the check is inclusive at both ends

**Red-before-green:** with `git stash push -- src/yasbd/boundary_detector.py`, all 5 negative tests fail against pristine code; restored, all 88 in the file pass.

## Suite status

Bench set up per CONTRIBUTING (`python -m venv` + `pip install -e .`, plus `pytest`/`pytest-cov`/`ruff`/`langcodes`). On Windows / Python 3.12:

- `pytest` — **112 passed**, 2 skipped, 1028 subtests passed, 2 failed
- `ruff check src tests` — clean

The 2 failures are pre-existing doctests in `src/yasbd/utils/language_classifier.py` and `src/yasbd/cli.py` that need optional deps I don't have installed; they fail identically before this branch.

One note in case it's useful: `pip install -e ".[dev]"` fails here because the resolver pulls `sentsplit` from the `bench` extra, which fails to build on Windows with a `UnicodeDecodeError` reading its own metadata. Installing `.` and the dev tools separately works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)