### PR TITLE
Add boundary-level scorer and metrics documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ Tested against 7 competitors (pysbd, sentencex, sentsplit, nupunkt, blingfire, s
 
 **TL;DR:** yasbd ranked #1 in accuracy across almost every test, while staying competitive on speed as pure Python. blingfire is faster but brittle. pysbd and sentencex shred French abbreviations.
 
-On our [golden benchmark](https://github.com/speedyk-005/yasbd-lib/tree/main/benchmarks#en-golden-benchmark) (92 English edge cases — expanded from pysbd's original 48 with fixes and additions): yasbd scores **98.9%**, pysbd **83.7%**, spaCy-sentencizer **55.4%**, etc.
+On our [golden benchmark](https://github.com/speedyk-005/yasbd-lib/tree/main/benchmarks#en-golden-benchmark) (92 English edge cases — expanded from pysbd's original 48 with fixes and additions): yasbd scores **98.9%**, pysbd **83.7%**, spaCy-sentencizer **55.4%**, etc. Against same boundary-level metrics, yasbd leads in **Precision 100.0%** / **Recall 99.3%** / **F1 99.7%**, with pysbd next at F1 **93.8%**.
 
-Full results, terminal output, and a performance graph can be found in **[benchmarks/](https://github.com/speedyk-005/yasbd-lib/tree/main/benchmarks)**
+Full results, terminal output, boundary-level (Precision/Recall/F1) metrics, and a performance graph can be found in **[benchmarks/](https://github.com/speedyk-005/yasbd-lib/tree/main/benchmarks)**
 
 **SPOILER**: Yasbd aced 'em all in accuracy while offering balanced speed. On _Adventures of Sherlock Holmes_ (594k chars), yasbd is ~8× faster than pysbd (1.2s vs 9.0s warm) with far fewer false splits.
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -28,16 +28,29 @@ The format is simple: throw edge cases at each library. Does it split where it s
 
 Aggregate score across all 92 English edge cases in [`EN_GOLDEN_DATA.py`](https://github.com/speedyk-005/yasbd-lib/blob/main/benchmarks/EN_GOLDEN_DATA.py) via [`run_golden.py`](https://github.com/speedyk-005/yasbd-lib/blob/main/benchmarks/run_golden.py). Expanded from pysbd's original 48 to 92 cases: we removed biased/wrong expectations (like splitting mid-ellipsis or bad punctuation in dialog) and added cases for abbreviation chains, contiguous terminators, exclamation-safe words, academic citations, and more.
 
-| Library | Score |
-|---|---|
-| **yasbd** | 91/92 (98.9%) |
-| pysbd | 77/92 (83.7%) |
-| sentencex | 76/92 (82.6%) |
-| blingfire | 75/92 (81.5%) |
-| sentsplit | 61/92 (66.3%) |
-| sentence-splitter | 60/92 (65.2%) |
-| nupunkt | 59/92 (64.1%) |
-| spacy-sentencizer | 51/92 (55.4%) |
+The **Passed** column is a strict sentence-string equality check. Alongside it, we report boundary-level **Precision**, **Recall**, and **F1** computed by [`scorer.py`](https://github.com/speedyk-005/yasbd-lib/blob/main/benchmarks/scorer.py).
+
+### Boundary metric methodology
+
+`evaluate_segmentation` scores against the *positions* where sentences end, not the sentence strings themselves, so a boundary that is merely shifted (e.g. trailing whitespace) still counts toward accuracy. Implementation:
+
+1. **Word-level binary arrays.** Every sentence is split into words. The final word of each sentence is marked `1` (a sentence boundary); all other words are marked `0`.
+2. **Alignment.** If the model dropped or added words, the two arrays differ in length. The shorter array is right-justified with `0` padding so both arrays share the final word's boundary marker.
+3. **Confusion counts.** Each aligned word position is a True Positive (`1`/`1`), False Positive (`0`/`1`), or False Negative (`1`/`0`).
+4. **Averages.** TP/FP/FN are summed across all 92 cases, then Precision = TP ÷ (TP+FP), Recall = TP ÷ (TP+FN), and F1 = the harmonic mean of the two.
+
+All three are bounded `[0, 1]`; they fall back to `0.0` when no useful boundary signal exists (e.g. an empty gold).
+
+| Library | Passed | Precision | Recall | F1 |
+|---|---|---|---|---|
+| **yasbd** | 91/92 (98.9%) | 100.0% | 99.3% | 99.7% |
+| pysbd | 77/92 (83.7%) | 90.5% | 97.3% | 93.8% |
+| sentencex | 77/92 (83.7%) | 89.7% | 94.6% | 92.1% |
+| blingfire | 75/92 (81.5%) | 86.7% | 93.2% | 89.8% |
+| sentsplit | 61/92 (66.3%) | 89.9% | 85.0% | 87.4% |
+| sentence-splitter | 60/92 (65.2%) | 80.1% | 90.5% | 85.0% |
+| nupunkt | 59/92 (64.1%) | 77.9% | 91.2% | 84.0% |
+| spacy-sentencizer | 51/92 (55.4%) | 75.7% | 89.1% | 81.9% |
 
 yasbd achieves 91/92 (98.9%). The only failing case is the `Ave.` abbreviation followed by a capitalized new sentence — a known limitation of rule-based abbreviation suppression. 
 

--- a/benchmarks/run_golden.py
+++ b/benchmarks/run_golden.py
@@ -3,6 +3,7 @@ from EN_GOLDEN_DATA import GOLDEN_EN_RULES_TEST_CASES
 from rich import box
 from rich.console import Console
 from rich.table import Table
+from scorer import evaluate_segmentation
 
 console = Console()
 
@@ -19,6 +20,7 @@ def _evaluate_segmenter(seg, cases):
     passed = 0
     total = len(cases)
     failures = []
+    tp = fp = fn = 0
     for input_text, expected in cases:
         try:
             result = [s.strip() for s in seg.segment(input_text)]
@@ -28,7 +30,11 @@ def _evaluate_segmenter(seg, cases):
             passed += 1
         else:
             failures.append((input_text, expected, result))
-    return passed, total, failures
+        counts = evaluate_segmentation(result, expected)
+        tp += counts["tp"]
+        fp += counts["fp"]
+        fn += counts["fn"]
+    return passed, total, failures, tp, fp, fn
 
 
 def run_golden_tests():
@@ -46,19 +52,35 @@ def run_golden_tests():
     segmenters = all_segmenters(lang="en")
 
     for name, seg in sorted(segmenters.items()):
-        passed, total, failures = _evaluate_segmenter(seg, GOLDEN_EN_RULES_TEST_CASES)
+        passed, total, failures, tp, fp, fn = _evaluate_segmenter(
+            seg, GOLDEN_EN_RULES_TEST_CASES
+        )
         pct = passed / total * 100
+        precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+        recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+        f1 = (
+            2 * (precision * recall) / (precision + recall)
+            if (precision + recall) > 0
+            else 0.0
+        )
         report.append(
             {
                 "name": name,
                 "passed": passed,
                 "total": total,
                 "pct": pct,
+                "precision": precision,
+                "recall": recall,
+                "f1": f1,
+                "tp": tp,
+                "fp": fp,
+                "fn": fn,
                 "failures": failures,
             }
         )
 
         console.print(f"{name:20s} {passed:2d}/{total} ({pct:5.1f}%)", end="")
+        console.print(f"  P:{precision:5.1%} R:{recall:5.1%} F1:{f1:5.1%}", end="")
         if failures:
             shortest_failure = min(failures, key=lambda f: len(f[0]))
             console.print(f"  worst: {shortest_failure[0][:60]!r}")
@@ -70,6 +92,12 @@ def run_golden_tests():
     table.add_column("Library", style="cyan")
     table.add_column("Passed", justify="right")
     table.add_column("Score", justify="right", style="bold")
+    table.add_column("Precision", justify="right")
+    table.add_column("Recall", justify="right")
+    table.add_column("F1", justify="right", style="bold")
+    table.add_column("TP", justify="right")
+    table.add_column("FP", justify="right")
+    table.add_column("FN", justify="right")
 
     for r in sorted(report, key=lambda x: -x["pct"]):
         color = _score_color(r["pct"])
@@ -77,6 +105,12 @@ def run_golden_tests():
             r["name"],
             f"{r['passed']:2d}/{r['total']}",
             f"[{color}]{r['pct']:5.1f}%[/{color}]",
+            f"{r['precision']:5.1%}",
+            f"{r['recall']:5.1%}",
+            f"{r['f1']:5.1%}",
+            str(r["tp"]),
+            str(r["fp"]),
+            str(r["fn"]),
         )
 
     console.print("\n", table)

--- a/benchmarks/scorer.py
+++ b/benchmarks/scorer.py
@@ -1,0 +1,91 @@
+"""Boundary-level scoring for sentence boundary detection.
+
+Evaluates segmentation quality using word-level binary boundary arrays.
+A boundary array marks the index of each word that ends a sentence with ``1``
+and all other words with ``0``. Traditional Precision, Recall, and F1 are then
+derived from True Positive / False Positive / False Negative counts.
+"""
+
+
+def _to_binary(sentences: list[str]) -> list[int]:
+    """Convert segmented sentences into a word-level binary boundary array.
+
+    Each sentence is split on whitespace; every word except the last in a
+    sentence is marked ``0`` and the final word of each sentence is marked ``1``.
+    Empty sentences are skipped to keep the array aligned with real tokens.
+    """
+    binary: list[int] = []
+    for sent in sentences:
+        sent_len = len(sent.split())
+        if sent_len == 0:
+            continue
+        binary.extend([0] * (sent_len - 1))
+        binary.append(1)
+    return binary
+
+
+def _align_arrays(
+    gold_binary: list[int], pred_binary: list[int]
+) -> tuple[list[int], list[int]]:
+    """Align binary arrays of different lengths for positional comparison.
+
+    When the model drops or adds words, the two arrays can differ in length.
+    The shorter array is right-justified with ``0`` padding so both arrays share
+    their final word's boundary marker (``1``) at the same index. This keeps the
+    sentence-final boundary aligned without mutating the caller's arrays.
+    """
+    if len(gold_binary) == len(pred_binary):
+        return gold_binary, pred_binary
+
+    diff = len(gold_binary) - len(pred_binary)
+    if diff > 0:
+        pred_binary = [0] * diff + pred_binary
+    else:
+        gold_binary = [0] * (-diff) + gold_binary
+    return gold_binary, pred_binary
+
+
+def evaluate_segmentation(pred: list[str], gold: list[str]) -> dict[str, float]:
+    """SBD evaluation using word-level binary boundary arrays.
+
+    Converts both the predicted and gold segmentations into binary boundary
+    markers, aligns them when lengths differ, and computes Precision, Recall,
+    and F1 over the class of sentence-ending word positions.
+
+    Args:
+        pred: Predicted sentence boundaries as a list of sentence strings.
+        gold: Ground-truth sentence boundaries as a list of sentence strings.
+
+    Returns:
+        A dict with ``"precision"``, ``"recall"``, ``"f1"``, ``"tp"``, ``"fp"``,
+        and ``"fn"``. Precision/Recall/F1 fall back to ``0.0`` when their
+        denominator is zero and the arrays contain no useful boundary signal.
+    """
+    gold_binary = _to_binary(gold)
+    pred_binary = _to_binary(pred)
+
+    gold_binary, pred_binary = _align_arrays(gold_binary, pred_binary)
+
+    tp = fp = fn = 0
+    for g, p in zip(gold_binary, pred_binary, strict=True):
+        if g == 1 and p == 1:
+            tp += 1
+        elif g == 0 and p == 1:
+            fp += 1
+        elif g == 1 and p == 0:
+            fn += 1
+
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    f1_score = (
+        2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0.0
+    )
+
+    return {
+        "precision": precision,
+        "recall": recall,
+        "f1": f1_score,
+        "tp": tp,
+        "fp": fp,
+        "fn": fn,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ bench = [
   "nupunkt; python_version >= '3.11'",
   "blingfire",
   "sentence-splitter",
+  "spacy",
   "setuptools<81",
   "matplotlib",
   "rich",


### PR DESCRIPTION
## Objective

Add boundary-level Precision, Recall, and F1 metrics to the golden benchmark pipeline so accuracy can be measured at the sentence-boundary level, not just as binary pass/fail sentence-string equality.

## Changes

- Added `benchmarks/scorer.py` with `evaluate_segmentation(pred, gold)`, which converts both segmentations into word-level binary boundary arrays, aligns arrays of differing lengths, and returns Precision, Recall, F1, plus TP/FP/FN.
- Wired the scorer into `benchmarks/run_golden.py`: per-library output now shows P/R/F1, and the summary table gains Precision, Recall, F1, TP, FP, and FN columns alongside Passed/Score.
- Documented the boundary-metric methodology and added P/R/F1 columns to the golden summary table in `benchmarks/README.md`; referenced the new metrics in the top-level `README.md`.
- Added `spacy` to the `bench` extras so the full pipeline runs end-to-end.

### Types of change

- [x] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [x] Documentation update
- [ ] Other (please describe):

## Verification

- [ ] I ran `pytest` and all tests pass.
- [x] I ran `ruff format` and `ruff check --fix` on the changed files.
- [ ] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #265