### PR TITLE
Isolate external lang packs per detector instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## Unreleased
+
+### Changed
+
+- **Per-instance lang pack registry** ([#270](https://github.com/speedyk-005/yasbd-lib/pull/270)): Removed global `_LANG_PACK_REGISTRY`. `BoundaryDetector` now accepts `external_lang_packs` param and manages its own isolated registry. `register_lang_packs` renamed to `load_external_lang_packs`. `clear_lang_packs` removed.
+
+---
+
 ## [0.15.1] - 2026-08-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Regex is how I cut. Not what I am. My brain is a two-pass pipeline:
 > [!NOTE]
 > **v1.x freeze:** The built-in language set is locked for the v1.x series (reached with Armenian; see #132 / #198).
 > New languages are **not** accepted as built-in modules. They should be distributed as external packs.
-> Use [lang packs](#-lang-packs) via `register_lang_packs()` instead. Focus for core
+> Use [lang packs](#-lang-packs) via `BoundaryDetector(external_lang_packs=[...])` instead. Focus for core
 > stays on bug fixes, edge cases, and API stabilization. Non-breaking improvements
 > to *existing* language rules are still welcome.
 
@@ -235,6 +235,11 @@ detector = BoundaryDetector(
 	# https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
     lang="fr",
 
+    # Optional external language pack modules to load. Defaults to `None`.
+    # Each pack is validated and stored in a private registry for this detector only.
+    # Check #-lang-packs for more.
+    external_lang_packs=["yasbd_auxlang"],
+
     # Don't split inside them. (It won't protect block quotes) Defaults to `True`.
     # https://en.wikipedia.org/wiki/Block_quotation
     preserve_quote_and_paren=True,
@@ -243,6 +248,8 @@ detector = BoundaryDetector(
     verbose=True,
 )
 ```
+
+If you want to know more about Lang Packs check the [Lang packs](#-lang-packs) section.
 
 > [!TIP]
 > **Language tag normalization:**
@@ -445,7 +452,7 @@ echo "Hello. World." | yasbd segment | cat
 
 # Load external language pack and segment a mono-profile pack
 pip install yasbd-union
-yasbd segment --from-pack yasbd_union "Hello. World."
+yasbd segment --from-pack yasbd_union --lang xx "Hello. World."
 # [1] 'Hello.'
 # [2] 'World.'
 
@@ -562,24 +569,14 @@ pipe.preserve_quote_and_paren = False
 Need support for a language that isn't built in? Plug in your own lang pack. A lang pack is simply a Python module that exposes a `PROFILES` list of `Rules` subclasses.
 
 ```python
-from yasbd.rules import register_lang_packs
-# Or from yasbd import register_lang_packs
+from yasbd import BoundaryDetector
 
-registered = register_lang_packs(["my_yasbd_pack"])
-print(registered)  # e.g. ["xx", "eo"]
-```
-
-To reset the registry at runtime:
-
-```python
-from yasbd.rules import clear_lang_packs
-# Or from yasbd import clear_lang_packs
-
-clear_lang_packs()
+detector = BoundaryDetector(lang="eo", external_lang_packs=["yasbd_auxlang"])
+detector.segment("Saluton. Kiel vi fartas?")
 ```
 
 > [!CAUTION]
-> **Security**: `register_lang_packs()` imports arbitrary Python modules by name. Only load lang packs from sources you trust — an untrusted module can execute arbitrary code at import time.
+> **Security**: `load_external_lang_packs()` imports arbitrary Python modules by name. Only load lang packs from sources you trust — an untrusted module can execute arbitrary code at import time.
 
 Want to build a lang pack? Start with the [language template](https://github.com/speedyk-005/yasbd-lib/blob/main/src/yasbd/rules/_template.py).
 

--- a/src/yasbd/__init__.py
+++ b/src/yasbd/__init__.py
@@ -9,7 +9,7 @@ from yasbd.exceptions import (
     UnsupportedLanguageError,
     YasbdError,
 )
-from yasbd.rules import clear_lang_packs, get_supported_langs, register_lang_packs
+from yasbd.rules import get_supported_langs
 
 try:
     __version__ = version("yasbd-lib")
@@ -52,8 +52,6 @@ __all__ = [
     "UnsupportedLanguageError",
     "YasbdError",
     "__version__",
-    "clear_lang_packs",
     "get_supported_langs",
-    "register_lang_packs",
     "register_spacy_component",
 ]

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -78,7 +78,9 @@ class BoundaryDetector:
         self.verbose = verbose
         self.hook = hook
         self._rule_cache: OrderedDict[str, object] = OrderedDict()
-        self._ext_registry: dict = load_external_lang_packs(external_lang_packs)
+        self._ext_registry: dict = load_external_lang_packs(
+            external_lang_packs or [], verbose=verbose
+        )
 
         if not lang:
             raise InvalidInputError(

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -78,10 +78,7 @@ class BoundaryDetector:
         self.verbose = verbose
         self.hook = hook
         self._rule_cache: OrderedDict[str, object] = OrderedDict()
-
-        self._ext_registry: dict = {}
-        if external_lang_packs:
-            load_external_lang_packs(external_lang_packs, self._ext_registry)
+        self._ext_registry: dict = load_external_lang_packs(external_lang_packs)
 
         if not lang:
             raise InvalidInputError(

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -51,8 +51,8 @@ class BoundaryDetector:
         *,
         external_lang_packs: list[str] | None = None,
         preserve_quote_and_paren: bool = True,
-        verbose: bool = False,
         hook: Callable[[HookContext], None] | None = None,
+        verbose: bool = False,
     ):
         """Initialize the boundary detector.
 
@@ -66,13 +66,13 @@ class BoundaryDetector:
                 and stored in a private registry that only this detector uses.
             preserve_quote_and_paren: Do not split on terminators inside
                 quoted or parenthesised text.
-            verbose: Enable verbose logging.
             hook: Optional per-paragraph post-processing callback. Receives
                 a dict with ``text``, ``lang``, ``boundaries`` and
                 ``paragraph_index`` keys; mutate ``boundaries`` in place to
                 add or remove sentence boundaries. Reassigning
                 ``ctx["boundaries"]`` to a new list also works, though
                 in-place mutation is recommended.
+            verbose: Enable verbose logging.
         """
         self.preserve_quote_and_paren = preserve_quote_and_paren
         self.verbose = verbose

--- a/src/yasbd/boundary_detector.py
+++ b/src/yasbd/boundary_detector.py
@@ -5,7 +5,7 @@ from itertools import chain, pairwise, tee
 from typing import TypedDict
 
 from yasbd.exceptions import HookError, InvalidInputError
-from yasbd.rules import get_supported_langs, load_rule
+from yasbd.rules import get_supported_langs, load_external_lang_packs, load_rule
 from yasbd.utils.cleaner_stub import StreamCleanerStub
 from yasbd.utils.input_validator import validate_input
 from yasbd.utils.language_classifier import classify_language
@@ -49,6 +49,7 @@ class BoundaryDetector:
         self,
         lang: str | None = None,
         *,
+        external_lang_packs: list[str] | None = None,
         preserve_quote_and_paren: bool = True,
         verbose: bool = False,
         hook: Callable[[HookContext], None] | None = None,
@@ -60,6 +61,9 @@ class BoundaryDetector:
                 Use 'auto' for automatic language detection via py3langid.
                 Explicit is faster and more reliable; use auto if you don't
                 mind a slight decrease in both.
+            external_lang_packs: Optional list of external language pack module
+                names to load (e.g. ``["yasbd_legal"]``). Each pack is validated
+                and stored in a private registry that only this detector uses.
             preserve_quote_and_paren: Do not split on terminators inside
                 quoted or parenthesised text.
             verbose: Enable verbose logging.
@@ -74,6 +78,10 @@ class BoundaryDetector:
         self.verbose = verbose
         self.hook = hook
         self._rule_cache: OrderedDict[str, object] = OrderedDict()
+
+        self._ext_registry: dict = {}
+        if external_lang_packs:
+            load_external_lang_packs(external_lang_packs, self._ext_registry)
 
         if not lang:
             raise InvalidInputError(
@@ -133,7 +141,7 @@ class BoundaryDetector:
             self._rule_cache.move_to_end(lang)
             return self._rule_cache[lang]
 
-        rule = load_rule(lang, verbose=self.verbose)
+        rule = load_rule(lang, ext_registry=self._ext_registry, verbose=self.verbose)
         self._rule_cache[lang] = rule
 
         if len(self._rule_cache) > _MAX_CACHED_RULES:

--- a/src/yasbd/cli.py
+++ b/src/yasbd/cli.py
@@ -18,7 +18,6 @@ from yasbd import (
     UnsupportedLanguageError,
     __version__,
     get_supported_langs,
-    register_lang_packs,
 )
 
 cli = Radicli(
@@ -68,14 +67,6 @@ def _stdin_is_pipe() -> bool:
 def _stdout_is_pipe() -> bool:
     """Check if stdout is a pipe (redirected to another process)."""
     return stat.S_ISFIFO(os.fstat(1).st_mode)
-
-
-def _resolve_lang(lang: Optional[str], from_pack: Optional[list[str]]) -> str | None:
-    """Register packs and resolve language. Returns lang or None."""
-    registered = register_lang_packs(from_pack) if from_pack else []
-    if lang is None and len(registered) == 1:
-        lang = registered[0]
-    return lang
 
 
 def _create_external_cleaner(command_str: str) -> Callable[[str], str]:
@@ -241,8 +232,12 @@ def segment(
     Writes enumerated sentences to stdout or JSONL to --destination.
     """
     with _resolve_input(text, file) as input_text:
-        lang = _resolve_lang(lang, from_pack)
-        detector = BoundaryDetector(lang=lang, preserve_quote_and_paren=True, verbose=verbose)
+        detector = BoundaryDetector(
+            lang=lang,
+            external_lang_packs=from_pack,
+            preserve_quote_and_paren=True,
+            verbose=verbose,
+        )
         _output(
             detector.segment(input_text, preserve_whitespace=preserve_whitespace),
             destination,
@@ -276,8 +271,12 @@ def detect(
     Use --relative for per-paragraph offsets (ParagraphEOF marks gaps).
     """
     with _resolve_input(text, file) as input_text:
-        lang = _resolve_lang(lang, from_pack)
-        detector = BoundaryDetector(lang=lang, preserve_quote_and_paren=True, verbose=verbose)
+        detector = BoundaryDetector(
+            lang=lang,
+            external_lang_packs=from_pack,
+            preserve_quote_and_paren=True,
+            verbose=verbose,
+        )
         _output(
             detector.detect(input_text, relative=relative),
             destination,

--- a/src/yasbd/rules/__init__.py
+++ b/src/yasbd/rules/__init__.py
@@ -6,11 +6,6 @@ from pathlib import Path
 from yasbd.exceptions import LangPackError, UnsupportedLanguageError
 from yasbd.utils.logger import log_info
 from yasbd.rules.base import Rules
-from yasbd.utils.input_validator import validate_input
-
-# Language packs loaded via register_lang_packs() register their profiles here.
-# Maps language code to (pack name, Rules subclass).
-_LANG_PACK_REGISTRY = {}
 
 
 def _validate_profile(profile: type, name: str) -> None:
@@ -28,12 +23,11 @@ def _validate_profile(profile: type, name: str) -> None:
         raise TypeError(f"Profile {profile.__name__!r} must not override apply().")
 
 
-@validate_input
-def register_lang_packs(names: list[str]) -> list[str]:
+def load_external_lang_packs(names: list[str], registry: dict | None = None) -> list[str]:
     """Import and validate external language pack modules.
 
     Each module must expose a ``PROFILES`` list of ``Rules`` subclasses.
-    All validated profiles are stored in ``_LANG_PACK_REGISTRY``.
+    If *registry* is provided, validated profiles are stored in it.
 
     Caution:
         This function imports arbitrary Python modules by name. Only load lang
@@ -43,6 +37,8 @@ def register_lang_packs(names: list[str]) -> list[str]:
     Args:
         names: Module names resolvable from the Python path
             (e.g. ``["yasbd_indic", "yasbd_legal"]``).
+        registry: Optional dict to store registered profiles in.
+            If ``None``, profiles are validated but not stored.
 
     Returns:
         List of registered language codes (e.g. ``["xx", "eo"]``).
@@ -72,7 +68,8 @@ def register_lang_packs(names: list[str]) -> list[str]:
             try:
                 _validate_profile(profile, name)
                 lang_code = profile.__name__.removesuffix("Rules").lower()
-                _LANG_PACK_REGISTRY[lang_code] = (name, profile)
+                if registry is not None:
+                    registry[lang_code] = (name, profile)
                 registered.append(lang_code)
             except (TypeError, RuntimeError) as e:
                 raise LangPackError(
@@ -84,12 +81,6 @@ def register_lang_packs(names: list[str]) -> list[str]:
     return registered
 
 
-def clear_lang_packs() -> None:
-    """Remove all registered language packs and reset the supported-languages cache."""
-    _LANG_PACK_REGISTRY.clear()
-    get_supported_langs.cache_clear()
-
-
 @cache
 def get_supported_langs() -> list[str]:
     """Discover and cache supported language codes.
@@ -98,19 +89,24 @@ def get_supported_langs() -> list[str]:
     the built-in rules directory and any registered language packs.
     """
     rules_dir = Path(__file__).parent
-    langs = set(_LANG_PACK_REGISTRY.keys())
-    for f in rules_dir.iterdir():
-        if f.stem in ("_template", "base", "__init__"):
-            continue
-        if f.suffix == ".py":
-            langs.add(f.stem)
+    langs = {
+        f.stem
+        for f in rules_dir.iterdir()
+        if f.suffix == ".py" and f.stem not in ("_template", "base", "__init__")
+    }
     return ["auto", *sorted(langs)]
 
 
-def load_rule(lang: str, *, verbose: bool = False) -> Rules:
+def load_rule(lang: str, *, ext_registry: dict, verbose: bool = False) -> Rules:
     """Import and instantiate the rule module for *lang*.
 
-    Checks the language pack registry first; falls back to the built-in rules directory.
+    Checks *ext_registry* first; falls back to the built-in rules directory.
+
+    Args:
+        lang: Language code (e.g. ``"en"``, ``"fr"``).
+        ext_registry: Dict of ``{lang_code: (pack_name, Rules_class)}``
+            entries to check before built-in rules.
+        verbose: Enable verbose logging.
 
     Returns:
         The instantiated rule object.
@@ -118,7 +114,7 @@ def load_rule(lang: str, *, verbose: bool = False) -> Rules:
     Raises:
         UnsupportedLanguageError: If no rule module exists for *lang*.
     """
-    if profile_data := _LANG_PACK_REGISTRY.get(lang):
+    if profile_data := ext_registry.get(lang):
         name, cls = profile_data
         log_info(verbose, "{} ({}) is loaded successfully", lang, name)
         return cls()

--- a/src/yasbd/rules/__init__.py
+++ b/src/yasbd/rules/__init__.py
@@ -23,11 +23,10 @@ def _validate_profile(profile: type, name: str) -> None:
         raise TypeError(f"Profile {profile.__name__!r} must not override apply().")
 
 
-def load_external_lang_packs(names: list[str], registry: dict | None = None) -> list[str]:
+def load_external_lang_packs(names: list[str]) -> dict:
     """Import and validate external language pack modules.
 
     Each module must expose a ``PROFILES`` list of ``Rules`` subclasses.
-    If *registry* is provided, validated profiles are stored in it.
 
     Caution:
         This function imports arbitrary Python modules by name. Only load lang
@@ -37,16 +36,14 @@ def load_external_lang_packs(names: list[str], registry: dict | None = None) -> 
     Args:
         names: Module names resolvable from the Python path
             (e.g. ``["yasbd_indic", "yasbd_legal"]``).
-        registry: Optional dict to store registered profiles in.
-            If ``None``, profiles are validated but not stored.
 
     Returns:
-        List of registered language codes (e.g. ``["xx", "eo"]``).
+        Dict of ``{lang_code: (pack_name, Rules_class)}`` entries.
 
     Raises:
         LangPackError: If a language pack module cannot be imported.
     """
-    registered: list[str] = []
+    registry: dict = {}
     for name in names:
         try:
             mod = import_module(name)
@@ -68,9 +65,7 @@ def load_external_lang_packs(names: list[str], registry: dict | None = None) -> 
             try:
                 _validate_profile(profile, name)
                 lang_code = profile.__name__.removesuffix("Rules").lower()
-                if registry is not None:
-                    registry[lang_code] = (name, profile)
-                registered.append(lang_code)
+                registry[lang_code] = (name, profile)
             except (TypeError, RuntimeError) as e:
                 raise LangPackError(
                     f"Validation failed for {profile.__name__!r} in module {name!r}.\n"
@@ -78,7 +73,7 @@ def load_external_lang_packs(names: list[str], registry: dict | None = None) -> 
                 ) from e
 
     get_supported_langs.cache_clear()
-    return registered
+    return registry
 
 
 @cache

--- a/src/yasbd/rules/__init__.py
+++ b/src/yasbd/rules/__init__.py
@@ -50,12 +50,12 @@ def load_external_lang_packs(names: list[str], registry: dict | None = None) -> 
     for name in names:
         try:
             mod = import_module(name)
-        except ImportError as e:
+        except ImportError:
             raise LangPackError(
                 f"Language pack module {name!r} could not be imported. "
                 "Make sure it is installed and on the Python path.\n"
                 f"💡 Try: pip install {name}"
-            ) from e
+            ) from None
 
         profiles = getattr(mod, "PROFILES", None)
         if profiles is None:

--- a/src/yasbd/rules/__init__.py
+++ b/src/yasbd/rules/__init__.py
@@ -1,4 +1,5 @@
 import difflib
+import warnings
 from functools import cache
 from importlib import import_module
 from pathlib import Path
@@ -23,7 +24,7 @@ def _validate_profile(profile: type, name: str) -> None:
         raise TypeError(f"Profile {profile.__name__!r} must not override apply().")
 
 
-def load_external_lang_packs(names: list[str]) -> dict:
+def load_external_lang_packs(names: list[str], *, verbose: bool = False) -> dict:
     """Import and validate external language pack modules.
 
     Each module must expose a ``PROFILES`` list of ``Rules`` subclasses.
@@ -36,6 +37,7 @@ def load_external_lang_packs(names: list[str]) -> dict:
     Args:
         names: Module names resolvable from the Python path
             (e.g. ``["yasbd_indic", "yasbd_legal"]``).
+        verbose: Enable verbose logging.
 
     Returns:
         Dict of ``{lang_code: (pack_name, Rules_class)}`` entries.
@@ -65,7 +67,21 @@ def load_external_lang_packs(names: list[str]) -> dict:
             try:
                 _validate_profile(profile, name)
                 lang_code = profile.__name__.removesuffix("Rules").lower()
+                if lang_code in registry:
+                    prev_name, _ = registry[lang_code]
+                    warnings.warn(
+                        f"Language pack {name!r} overrides {prev_name!r}"
+                        f" for lang {lang_code!r}",
+                        stacklevel=2,
+                    )
                 registry[lang_code] = (name, profile)
+                log_info(
+                    verbose,
+                    "Registered {} ({}) from {}",
+                    lang_code,
+                    profile.__name__,
+                    name,
+                )
             except (TypeError, RuntimeError) as e:
                 raise LangPackError(
                     f"Validation failed for {profile.__name__!r} in module {name!r}.\n"

--- a/tests/test_lang_packs.py
+++ b/tests/test_lang_packs.py
@@ -30,14 +30,14 @@ def _cleanup():
 def test_import_error():
     """Test that load_external_lang_packs raises error for an unresolvable module."""
     with pytest.raises(LangPackError, match="could not be imported"):
-        load_external_lang_packs(["_test_lang_pack_nonexistent"], {})
+        load_external_lang_packs(["_test_lang_pack_nonexistent"])
 
 
 def test_no_profiles():
     """Test that load_external_lang_packs raises error when a module has no PROFILES."""
     _make_fake_lang_pack("_test_lang_pack_noprofiles")
     with pytest.raises(LangPackError, match="has no PROFILES list"):
-        load_external_lang_packs(["_test_lang_pack_noprofiles"], {})
+        load_external_lang_packs(["_test_lang_pack_noprofiles"])
 
 
 def test_non_rules_profile():
@@ -49,7 +49,7 @@ def test_non_rules_profile():
 
     _make_fake_lang_pack("_test_lang_pack_notrules", profiles=[NotRules])
     with pytest.raises(LangPackError, match="Validation failed for 'NotRules'"):
-        load_external_lang_packs(["_test_lang_pack_notrules"], {})
+        load_external_lang_packs(["_test_lang_pack_notrules"])
 
 
 def test_handshake_override_apply():
@@ -61,18 +61,17 @@ def test_handshake_override_apply():
 
     _make_fake_lang_pack("_test_lang_pack_wrong_return", profiles=[WrongReturn])
     with pytest.raises(LangPackError, match="must not override apply"):
-        load_external_lang_packs(["_test_lang_pack_wrong_return"], {})
+        load_external_lang_packs(["_test_lang_pack_wrong_return"])
 
 
 def test_register_and_load():
-    """Test that load_external_lang_packs stores a profile and load_rule returns an instance."""
+    """Test that load_external_lang_packs returns a registry and load_rule returns an instance."""
 
     class FakeRules(Rules):
         pass
 
-    registry: dict = {}
     _make_fake_lang_pack("_test_lang_pack_load", profiles=[FakeRules])
-    load_external_lang_packs(["_test_lang_pack_load"], registry)
+    registry = load_external_lang_packs(["_test_lang_pack_load"])
     assert "fake" in registry, "Profile not registered"
     assert registry["fake"][1] is FakeRules, "Wrong class in registry"
     instance = load_rule("fake", ext_registry=registry)
@@ -85,22 +84,16 @@ def test_lang_pack_takes_precedence():
     class EnRules(Rules):
         pass
 
-    registry: dict = {}
     _make_fake_lang_pack("_test_lang_pack_override", profiles=[EnRules])
-    load_external_lang_packs(["_test_lang_pack_override"], registry)
+    registry = load_external_lang_packs(["_test_lang_pack_override"])
     instance = load_rule("en", ext_registry=registry)
     assert isinstance(instance, EnRules), "Lang pack did not override built-in EnRules"
 
 
-def test_no_registry_still_validates():
-    """Test that load_external_lang_packs validates without a registry."""
-
-    class FakeRules(Rules):
-        pass
-
-    _make_fake_lang_pack("_test_lang_pack_noreg", profiles=[FakeRules])
-    registered = load_external_lang_packs(["_test_lang_pack_noreg"])
-    assert registered == ["fake"]
+def test_returns_empty_dict_for_empty_input():
+    """Test that load_external_lang_packs returns empty dict for empty input."""
+    registry = load_external_lang_packs([])
+    assert registry == {}
 
 
 def test_boundary_detector_with_external_lang_packs():

--- a/tests/test_lang_packs.py
+++ b/tests/test_lang_packs.py
@@ -3,13 +3,9 @@ import types
 
 import pytest
 
+from yasbd import BoundaryDetector
 from yasbd.exceptions import LangPackError
-from yasbd.rules import (
-    _LANG_PACK_REGISTRY,
-    clear_lang_packs,
-    load_rule,
-    register_lang_packs,
-)
+from yasbd.rules import load_external_lang_packs, load_rule
 from yasbd.rules.base import Rules
 
 
@@ -24,29 +20,28 @@ def _make_fake_lang_pack(name: str, profiles: list | None = None) -> types.Modul
 
 @pytest.fixture(autouse=True)
 def _cleanup():
-    """Clean up injected modules and registry after each test."""
+    """Clean up injected modules after each test."""
     yield
     for name in list(sys.modules):
         if name.startswith("_test_lang_pack_"):
             del sys.modules[name]
-    clear_lang_packs()
 
 
 def test_import_error():
-    """Test that register_lang_packs raises error for an unresolvable module."""
+    """Test that load_external_lang_packs raises error for an unresolvable module."""
     with pytest.raises(LangPackError, match="could not be imported"):
-        register_lang_packs(["_test_lang_pack_nonexistent"])
+        load_external_lang_packs(["_test_lang_pack_nonexistent"], {})
 
 
 def test_no_profiles():
-    """Test that register_lang_packs raises error when a module has no PROFILES."""
+    """Test that load_external_lang_packs raises error when a module has no PROFILES."""
     _make_fake_lang_pack("_test_lang_pack_noprofiles")
     with pytest.raises(LangPackError, match="has no PROFILES list"):
-        register_lang_packs(["_test_lang_pack_noprofiles"])
+        load_external_lang_packs(["_test_lang_pack_noprofiles"], {})
 
 
 def test_non_rules_profile():
-    """Test that register_lang_packs rejects a non-Rules subclass in PROFILES."""
+    """Test that load_external_lang_packs rejects a non-Rules subclass in PROFILES."""
 
     class NotRules:
         def apply(self, text, _preserve_quote_and_paren):
@@ -54,11 +49,11 @@ def test_non_rules_profile():
 
     _make_fake_lang_pack("_test_lang_pack_notrules", profiles=[NotRules])
     with pytest.raises(LangPackError, match="Validation failed for 'NotRules'"):
-        register_lang_packs(["_test_lang_pack_notrules"])
+        load_external_lang_packs(["_test_lang_pack_notrules"], {})
 
 
 def test_handshake_override_apply():
-    """Test that register_lang_packs rejects a profile overriding apply()."""
+    """Test that load_external_lang_packs rejects a profile overriding apply()."""
 
     class WrongReturn(Rules):
         def apply(self, _text, _preserve_quote_and_paren):
@@ -66,20 +61,21 @@ def test_handshake_override_apply():
 
     _make_fake_lang_pack("_test_lang_pack_wrong_return", profiles=[WrongReturn])
     with pytest.raises(LangPackError, match="must not override apply"):
-        register_lang_packs(["_test_lang_pack_wrong_return"])
+        load_external_lang_packs(["_test_lang_pack_wrong_return"], {})
 
 
 def test_register_and_load():
-    """Test that register_lang_packs stores a profile and load_rule returns an instance."""
+    """Test that load_external_lang_packs stores a profile and load_rule returns an instance."""
 
     class FakeRules(Rules):
         pass
 
+    registry: dict = {}
     _make_fake_lang_pack("_test_lang_pack_load", profiles=[FakeRules])
-    register_lang_packs(["_test_lang_pack_load"])
-    assert "fake" in _LANG_PACK_REGISTRY, "Profile not registered"
-    assert _LANG_PACK_REGISTRY["fake"][1] is FakeRules, "Wrong class in registry"
-    instance = load_rule("fake")
+    load_external_lang_packs(["_test_lang_pack_load"], registry)
+    assert "fake" in registry, "Profile not registered"
+    assert registry["fake"][1] is FakeRules, "Wrong class in registry"
+    instance = load_rule("fake", ext_registry=registry)
     assert isinstance(instance, FakeRules), "load_rule returned wrong type"
 
 
@@ -89,20 +85,32 @@ def test_lang_pack_takes_precedence():
     class EnRules(Rules):
         pass
 
+    registry: dict = {}
     _make_fake_lang_pack("_test_lang_pack_override", profiles=[EnRules])
-    register_lang_packs(["_test_lang_pack_override"])
-    instance = load_rule("en")
+    load_external_lang_packs(["_test_lang_pack_override"], registry)
+    instance = load_rule("en", ext_registry=registry)
     assert isinstance(instance, EnRules), "Lang pack did not override built-in EnRules"
 
 
-def test_clear_lang_packs():
-    """Test that clear_lang_packs empties the registry."""
+def test_no_registry_still_validates():
+    """Test that load_external_lang_packs validates without a registry."""
 
     class FakeRules(Rules):
         pass
 
-    _make_fake_lang_pack("_test_lang_pack_clear", profiles=[FakeRules])
-    register_lang_packs(["_test_lang_pack_clear"])
-    assert "fake" in _LANG_PACK_REGISTRY
-    clear_lang_packs()
-    assert "fake" not in _LANG_PACK_REGISTRY, "Registry was not cleared"
+    _make_fake_lang_pack("_test_lang_pack_noreg", profiles=[FakeRules])
+    registered = load_external_lang_packs(["_test_lang_pack_noreg"])
+    assert registered == ["fake"]
+
+
+def test_boundary_detector_with_external_lang_packs():
+    """Test that BoundaryDetector loads external packs via external_lang_packs param."""
+
+    class FakeRules(Rules):
+        pass
+
+    _make_fake_lang_pack("_test_lang_pack_bd", profiles=[FakeRules])
+    detector = BoundaryDetector(lang="fake", external_lang_packs=["_test_lang_pack_bd"])
+    assert detector.lang == "fake"
+    rule = detector._get_rule("fake")
+    assert isinstance(rule, FakeRules), "BoundaryDetector did not load external pack"


### PR DESCRIPTION
## Objective

External lang packs shared a global registry, so loading a pack in one detector leaked into every other detector. Each `BoundaryDetector` now gets its own isolated registry.

## Changes

- Removed `_LANG_PACK_REGISTRY` and `clear_lang_packs` from `rules/__init__.py`
- Renamed `register_lang_packs` to `load_external_lang_packs`; takes an optional `registry` dict
- `load_rule` now requires an `ext_registry` kwarg
- `BoundaryDetector.__init__` takes `external_lang_packs=["pack_name"]`, creates a private registry, and loads packs itself
- CLI's `_resolve_lang` is gone — the CLI now passes `external_lang_packs` straight to `BoundaryDetector`
- Rewrote `tests/test_lang_packs.py` with 8 tests covering validation, isolation, and integration
- Added verbose logging and override warning to load_external_lang_packs

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] Code quality / performance improvement
- [x] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- None
