### PR TITLE
Fix false positive splits from corp abbreviation substring matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## Unreleased
+
+### Fixed
+
+- **Word boundary for corp entity abbreviations** ([#271](https://github.com/speedyk-005/yasbd-lib/pull/271)): Added `\b` to `CORP_ENTITY_ABBRVS` regex pattern to prevent substring matches (e.g., "co" inside "tobacco" was falsely matching as a corporate abbreviation).
+
+---
+
 ## [0.16.0] - 2026-08-26
 
 ### Changed

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -316,7 +316,7 @@ class Rules:
             ),
             re.compile(rf"""
                 (?:(?i:
-                    {build_optimized_pattern(cls.CORP_ENTITY_ABBRVS)}\.|
+                    \b{build_optimized_pattern(cls.CORP_ENTITY_ABBRVS)}\.|
                     {build_optimized_pattern(cls.NAMES_WITH_EXCLAMATION)}[! ！‼]
                 ))
                 (?!\s+(?:{cls.COMMON_STARTERS_PATTERN})\b)

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -218,6 +218,9 @@ def test_rule_cache_lru(en_detector):
         "Beta Corp. North America leads this hiring initiative.",
         "Martin Luther King Jr. Day is a paid holiday at this company.",
         "John Doe Sr. VP of Engineering will be your hiring manager.",
+
+        # CORP_ENTITY_ABBRVS must use word boundary (fix regression)
+        "Kid!| Don't buy tobacco.| Alright!",
     ],
 )
 def test_universal_regression(en_detector, marked_text):


### PR DESCRIPTION
## Objective

`CORP_ENTITY_ABBRVS` regex matched substrings inside words — "co" inside "tobacco" matched as a corporate abbreviation, suppressing sentence boundaries where they shouldn't be.

## Changes

- Added `\b` word boundary before `build_optimized_pattern(cls.CORP_ENTITY_ABBRVS)` in the no-split-after regex pattern in `rules/base.py`.
- Added regression test to `test_universal_regression` parametrize list.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [x] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- None
