### PR TITLE
Prevent list detection from re-adding abbreviation  boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Russian abbreviation coverage** ([#278](https://github.com/speedyk-005/yasbd-lib/pull/278)): Expanded `TITLE_ABBRVS`, `REFERENCE_ABBRVS`, and `INLINE_ONLY_ABBRVS` with missing Russian abbreviations, and added Cyrillic initial-chain handling to `MID_SENTENCE_FINDER_LST` to prevent false splits (e.g., `Арх. Иванов` and `Проф. Петров А.К.`).
+- **List boundary ordering** ([#277](https://github.com/speedyk-005/yasbd-lib/pull/277)): Run list boundary adjustment before mid-sentence filtering to prevent re-adding boundaries suppressed by abbreviation handling (e.g., `И т. д.` no longer splits).
 
 ---
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -450,6 +450,7 @@ class Rules:
         }
 
         # -- Remove false alarms --
+        self._adjust_list_boundaries(sentence_boundaries, text)
         sentence_boundaries.difference_update(
             m.end() for pat in self.MID_SENTENCE_FINDER_LST
             for m in pat.finditer(text)
@@ -459,7 +460,6 @@ class Rules:
             sentence_boundaries, text, preserve_quote_and_paren
         )
         self._remove_toc_spans(sentence_boundaries, text)
-        self._adjust_list_boundaries(sentence_boundaries, text)
 
         sentence_boundaries.update({0, len(text)})
         return sorted(sentence_boundaries)


### PR DESCRIPTION
## Objective

List boundary adjustment was re-adding sentence boundaries that abbreviation handling had just suppressed (e.g., `И т. д.` split into `И т.| д.`), because `_adjust_list_boundaries` ran after `MID_SENTENCE_FINDER_LST`.

## Changes

- Move `self._adjust_list_boundaries` in `src/yasbd/rules/base.py:apply` to run before `MID_SENTENCE_FINDER_LST` filtering (under `# -- Remove false alarms --`), so `MID` can suppress list re-added boundaries like `И т.`.
- Update `CHANGELOG.md` Unreleased with Fixed entry for this issue.

### Types of change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (language support, new utility, etc.)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [ ] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Part #273
