### PR TITLE
Fix shared abbreviations for tel. and fax. to prevent splitting in contact numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Telephone and fax abbreviations** ([#283](https://github.com/speedyk-005/yasbd-lib/issues/283)): Treat `tel.` and `fax.` as shared reference abbreviations before contact numbers across language profiles.
+- **Telephone and fax abbreviations** ([#284](https://github.com/speedyk-005/yasbd-lib/pull/284)): Treat `tel.` and `fax.` as shared reference abbreviations before contact numbers across language profiles.
 - **Russian abbreviation coverage** ([#278](https://github.com/speedyk-005/yasbd-lib/pull/278)): Expanded `TITLE_ABBRVS`, `REFERENCE_ABBRVS`, and `INLINE_ONLY_ABBRVS` with missing Russian abbreviations, and added Cyrillic initial-chain handling to `MID_SENTENCE_FINDER_LST` to prevent false splits (e.g., `Арх. Иванов` and `Проф. Петров А.К.`).
 - **List boundary ordering** ([#277](https://github.com/speedyk-005/yasbd-lib/pull/277)): Run list boundary adjustment before mid-sentence filtering to prevent re-adding boundaries suppressed by abbreviation handling (e.g., `И т. д.` no longer splits).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Telephone and fax abbreviations** ([#283](https://github.com/speedyk-005/yasbd-lib/issues/283)): Treat `tel.` and `fax.` as shared reference abbreviations before contact numbers across language profiles.
 - **Russian abbreviation coverage** ([#278](https://github.com/speedyk-005/yasbd-lib/pull/278)): Expanded `TITLE_ABBRVS`, `REFERENCE_ABBRVS`, and `INLINE_ONLY_ABBRVS` with missing Russian abbreviations, and added Cyrillic initial-chain handling to `MID_SENTENCE_FINDER_LST` to prevent false splits (e.g., `Арх. Иванов` and `Проф. Петров А.К.`).
 - **List boundary ordering** ([#277](https://github.com/speedyk-005/yasbd-lib/pull/277)): Run list boundary adjustment before mid-sentence filtering to prevent re-adding boundaries suppressed by abbreviation handling (e.g., `И т. д.` no longer splits).
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,6 +7,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@speedyk-005](https://github.com/speedyk-005)** | Maintainer & Creator |
 | **[@1cbyc](https://github.com/1cbyc)** | Coordinate direction abbreviation fix |
 | **[@AshSgDe29071999](https://github.com/AshSgDe29071999)** | Combined same-module imports in `__init__.py`; named cleaning-pipeline helpers for testability |
+| **[@be-student](https://github.com/be-student)** | Shared numeric-context telephone and fax abbreviation handling |
 | **[@cnaples79](https://github.com/cnaples79)** | Missing comma in set literals fix |
 | **[@ColumbusLabs](https://github.com/ColumbusLabs)** | Preserve word boundaries across StreamCleaner line breaks |
 | **[@ddelrio1986](https://github.com/ddelrio1986)** | Spelling and grammar fixes in docs |

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -96,7 +96,7 @@ class Rules:
         "est", "ex", "exs", "lat", "long", "max", "min",
 
         # Commerce / Measurements
-        "alt", "fam", "ord", "qty", "std", "wt",
+        "alt", "fam", "fax", "ord", "qty", "std", "tel", "wt",
 
         # Academic
         "et al", "s", "univ",

--- a/src/yasbd/rules/de.py
+++ b/src/yasbd/rules/de.py
@@ -50,7 +50,7 @@ class DeRules(Rules):
         "zzgl", "bspw", "insb", "ca", "bsp",
 
         # Business/Commercial
-        "fa", "fax",
+        "fa",
     }
 
     DATE_ABBRVS = Rules.DATE_ABBRVS | {

--- a/src/yasbd/rules/es.py
+++ b/src/yasbd/rules/es.py
@@ -24,7 +24,7 @@ class EsRules(Rules):
     }
 
     REFERENCE_ABBRVS = (Rules.REFERENCE_ABBRVS - {"no", "nos", "para"}) | {
-        "pág", "núm", "nro", "dir", "t", "tel", "trad", "asoc", "aprox",
+        "pág", "núm", "nro", "dir", "t", "trad", "asoc", "aprox",
         "cf", "incl", "cía", "s",
     }
 

--- a/src/yasbd/rules/pt.py
+++ b/src/yasbd/rules/pt.py
@@ -20,7 +20,7 @@ class PtRules(Rules):
     }
 
     REFERENCE_ABBRVS = (Rules.REFERENCE_ABBRVS - {"no", "nos", "para"}) | {
-        "pág", "pag", "págs", "pags", "núm", "num", "nro", "dir", "t", "tel", "trad",
+        "pág", "pag", "págs", "pags", "núm", "num", "nro", "dir", "t", "trad",
         "incl", "cia", "vol", "ed", "puj",
     }
 

--- a/tests/test_data/german.py
+++ b/tests/test_data/german.py
@@ -19,6 +19,7 @@ TEST_DATA = [
     "Wir sehen uns am Fr., 14. Feb.",
     "Sie finden es unter Nr. 1026.253.553.| Dort ist der Schatz.",
     "Wir wählen zuerst Option A.| Danach besprechen wir die Details.",
+    "Rufen Sie Tel. 555-0199 an.| Senden Sie ein Fax. 02-555 morgen.",
 
     # Structural headings
     "Kapitel 1. Der Anfang.| Es war dunkel und still im Raum. | Nichts bewegte sich.",

--- a/tests/test_data/italian.py
+++ b/tests/test_data/italian.py
@@ -24,6 +24,7 @@ TEST_DATA = [
     "È nato il 5 gen. 1990.",
     "La società è una S.P.A. con sede a Roma.",
     "La S.R.L. ha depositato il bilancio.",
+    "Chiama il tel. 555-0199.| Il fax. 02-555 è guasto.",
 
     # Structural headings
     "Capitolo 1. L'Inizio.| Era buio fuori.| Nulla si muoveva.",

--- a/tests/test_data/portuguese.py
+++ b/tests/test_data/portuguese.py
@@ -18,6 +18,7 @@ TEST_DATA = [
     "Veja o cap. 3 no t. II da obra.",
     "O art.º 4 e o n.º 8 são fundamentais.",
     "Liga ao dir. geral para o tel. 555-1234.",
+    "Liga ao tel. 555-0199.| Envia o fax. 02-555 amanhã.",
     "Comprei pão, leite, etc. para o jantar.",
     "Leia p. ex. o capítulo 5.",
     "Ontem disse-lhe que não.| 5 pessoas chegaram depois.",

--- a/tests/test_data/spanish.py
+++ b/tests/test_data/spanish.py
@@ -15,6 +15,7 @@ TEST_DATA = [
     "Vea el cap. 3 en el t. II de la obra.",
     "El art. 4 y el nro. 8 son clave.",
     "Llama al dir. general al tel. 555-1234.",
+    "Llama al tel. 555-0199.| Envía el fax. 02-555 mañana.",
     "Compré pan, leche, etc. para la cena.",
     "Lea p. ej. el capítulo 5.",
     "Ayer le dije que no.| 5 personas llegaron después.",


### PR DESCRIPTION
## Objective

Prevent `tel.` and `fax.` from splitting before contact numbers across language profiles.

## Changes

- Moved both abbreviations into the shared reference set and removed redundant Spanish, Portuguese, and German entries.
- Added Italian, German, Spanish, and Portuguese regression cases.
- Updated the changelog and contributor list.

### Types of change

- [x] Bug fix (non-breaking change fixing an issue)

## Verification

- [x] `pytest` — 118 passed, 2 skipped, 1,036 subtests passed.
- [x] Ruff checks pass on changed Python files.
- [x] Tests added to existing language fixtures.
- [x] Changelog updated.

## Related Issues

Fixes #283

AI assistance: OpenAI Codex helped inspect the rule inheritance, implement the change, and run validation. I reviewed the complete diff and test results.
