### PR TITLE
Prevent sentence split on pk., tgl., PT., and CV. abbreviations

### DIFF
--- a/src/yasbd/rules/id.py
+++ b/src/yasbd/rules/id.py
@@ -28,12 +28,12 @@ class IdRules(Rules):
     }
 
     CORP_ENTITY_ABBRVS = Rules.CORP_ENTITY_ABBRVS | {
-        "pte", "bhd", "sdn",
+        "pte", "bhd", "sdn", "pt", "cv",
     }
 
     REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
         "hlm", "hal", "bab", "jil", "lamp", "ttd", "stt",
-        "cet", "terj", "dok", "pas",
+        "cet", "terj", "dok", "pas", "pk", "tgl",
     }
 
     SECTION_MARKERS = Rules.SECTION_MARKERS | {

--- a/tests/test_data/indonesian.py
+++ b/tests/test_data/indonesian.py
@@ -3,22 +3,21 @@ TEST_DATA = [
     # Basic punctuation
     "Halo!| Apa kabar?| Baik-baik saja.",
     "Saya pergi ke pasar.| Ibu membeli sayur.",
-
     # Abbreviations
     "Dr. Soekarno adalah presiden pertama.| Beliau lahir di Surabaya.",
     "H. Abdul adalah seorang pengusaha.| Rumahnya di Jakarta.",
     "Ir. Soekarno dan Drs. Moh. Hatta memproklamasikan kemerdekaan.",
     "Baca hlm. 55 untuk detailnya.| Itu penting.",
     "Beli apel, jeruk, mangga, dll.| Jangan lupa kembali.",
-
+    "Rapat dimulai pk. 14.30 dan berakhir sore.",
+    "Dia lahir tgl. 15 Mei di Surabaya.",
+    "PT. Telkom dan CV. Karya turut hadir.",
     # Structural headings
     "Bab 1 membahas pendahuluan.| Bab 2 membahas metode.",
     "Pasal 5 mengatur hak dan kewajiban.| Pasal 6 mengatur sanksi.",
-
     # Parentheses and quotes
-    "Dia berkata, \"Saya akan datang.\"| Kami menunggunya.",
+    'Dia berkata, "Saya akan datang."| Kami menunggunya.',
     "Hasilnya (lihat tabel 3) menunjukkan peningkatan.| Sangat signifikan.",
-
     # Ellipsis
     "Dia berkata... lalu pergi.",
 ]


### PR DESCRIPTION


### 🔍 Summary of Changes
- Added `pt` and `cv` to `CORP_ENTITY_ABBRVS` in `src/yasbd/rules/id.py` to prevent sentence splitting after corporate entity prefixes (`PT.`, `CV.`).
- Added `pk` and `tgl` to `REFERENCE_ABBRVS` in `src/yasbd/rules/id.py` so periods are preserved when followed by numeric/time values (`pk. 14.30`, `tgl. 15 Mei`).
- Added test cases to `tests/test_data/indonesian.py` to ensure regression coverage.