### PR TITLE
Add 'mev' to TITLE_ABBRVS to prevent false sentence splits in Afrikaans

### DIFF
--- a/src/yasbd/rules/af.py
+++ b/src/yasbd/rules/af.py
@@ -5,7 +5,7 @@ from yasbd.rules.nl import NlRules
 class AfRules(NlRules):
 
     TITLE_ABBRVS = NlRules.TITLE_ABBRVS | {
-        "adv", "ds", "at", "mej", "me",
+        "adv", "ds", "at", "mej", "me", "mev",
     }
 
     DOTTED_GEOPOL_ABBRVS = NlRules.DOTTED_GEOPOL_ABBRVS | {

--- a/tests/test_data/afrikaans.py
+++ b/tests/test_data/afrikaans.py
@@ -17,6 +17,7 @@ TEST_DATA = [
     "Ons sien mekaar op vr. 14 Feb.",
     "Die vergadering is om 14.| Vandag bespreek ons die besonderhede.",
     "Die V.S. regering het 'n nuwe wet aangeneem.",
+    "Mev. Jansen praat.| Mnr. Botha luister.",
 
     # Structural headings
     "Hoofstuk 1. Die begin.| Dit was donker en stil in die kamer.| Niks het beweeg nie.",


### PR DESCRIPTION
Fixes #289

### Summary of Changes
- Added `"mev"` (mevrou = Mrs./Madam) to `TITLE_ABBRVS` in `src/yasbd/rules/af.py`.
- Added test case `"Mev. Jansen praat.| Mnr. Botha luister."` to `tests/test_data/afrikaans.py`.

### Validation
- Ran `pytest tests/test_boundary_detector.py -k af` verifying that the test fails without the fix and passes cleanly with it.