### PR TITLE
Fix German/Dutch unit abbreviations from splitting sentences

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,6 +19,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@JosephM961](https://github.com/JosephM961)** | Documentation additions and typo fixes |
 | **[@k-anushka14](https://github.com/k-anushka14)** | Removed unused timeout parameter from external cleaner; merged Pronouns & Demonstratives header into Pronouns |
 | **[@kernelpanic888](https://github.com/kernelpanic888)** | Non-German ordinal boundary inheritance fix |
+| **[@macjayz](https://github.com/macjayz)** | German/Dutch numeric and reference abbreviation fixes |
 | **[@MasRama](https://github.com/MasRama)** | Double boundary for `.\n` fix |
 | **[@Mayankshrey438](https://github.com/Mayankshrey438)** | Armenian language support & flattened list heuristic |
 | **[@MohammedAnasNathani](https://github.com/MohammedAnasNathani)** | Documentation for built-in language freeze |

--- a/src/yasbd/rules/de.py
+++ b/src/yasbd/rules/de.py
@@ -50,7 +50,7 @@ class DeRules(Rules):
         "zzgl", "bspw", "insb", "ca", "bsp",
 
         # Business/Commercial
-        "fa",
+        "fa", "Mio", "Mrd",
     }
 
     DATE_ABBRVS = Rules.DATE_ABBRVS | {

--- a/src/yasbd/rules/nl.py
+++ b/src/yasbd/rules/nl.py
@@ -31,7 +31,7 @@ class NlRules(DeRules):
         "bijl", "ca", "cf", "ed", "vert", "id",
 
         # Legal, Corporate, and Formal Citation Markers
-        "b.w", "gem", "coll", "hr", "c.q", "ov", "vp",
+        "b.w", "gem", "coll", "hr", "c.q", "ov", "vp", "d.d",
     }
 
     SECTION_MARKERS = Rules.SECTION_MARKERS | {
@@ -42,7 +42,7 @@ class NlRules(DeRules):
 
     INLINE_ONLY_ABBRVS = DeRules.INLINE_ONLY_ABBRVS | {
         "bijv", "ca", "d.w.z", "e.v.t.l", "excl", "incl",
-        "z.g.n",
+        "z.g.n", "mln", "m.b.t", "zgn",
     }
 
     DATE_ABBRVS = Rules.DATE_ABBRVS | {

--- a/tests/test_data/dutch.py
+++ b/tests/test_data/dutch.py
@@ -7,6 +7,10 @@ TEST_DATA = [
     "Heb je nummer 2 verwijderd?| Maak het alsjeblieft ongedaan.",
 
     # Abbreviations
+    "Het budget bedraagt 5 mln. euro.| Dat is veel.",
+    "Jan d.d. 10-03-2020 tekende het contract.| Piet deed dat niet.",
+    "Zie m.b.t. 2024 het jaarverslag.| Alles staat erin.",
+    "De zgn. Nederlandse aanpak werkt.| Wij gaan verder.",
     "Mijn naam is Jonas E. Schmidt.",
     "Blader alstublieft naar pag. 55.",
     "Ik kan de Mt. Fuji vanaf hier zien liggen.",

--- a/tests/test_data/german.py
+++ b/tests/test_data/german.py
@@ -7,6 +7,9 @@ TEST_DATA = [
     "Hast du die Nummer 2 entfernt?| Bitte mach es rückgängig.",
 
     # Abbreviations
+    "Die Kosten betrugen etwa 5 Mio. Euro.| Das ist viel.",
+    "Deutschland hat 83 Mio. Einwohner.| Das sind frische Zahlen.",
+    "Die Ausgaben betragen 2 Mrd. Euro.| Wir prüfen die Zahlen.",
     "Mein Name ist Jonas E. Schmidt.",
     "Bitte blättern Sie zu S. 55.",
     "Ich kann den Mt. Fuji von hier aus sehen.",


### PR DESCRIPTION
## Objective
Prevent German and Dutch unit/reference abbreviations from creating unwanted sentence boundaries.

## Changes
- Add German `Mio` and `Mrd` to the existing inline-only abbreviation set.
- Add Dutch `mln`, `m.b.t`, and `zgn` to its inline-only set; add `d.d` to the reference set, retaining the existing lookahead guard.
- Extend the existing German/Dutch language fixtures with seven regression cases covering all six abbreviations and real sentence boundaries after them.
- Add the required contributor entry.

The German expected outputs in the issue combine two sentences. These tests intentionally retain the genuine boundary after `Euro.` / `Einwohner.` while preventing the unwanted boundary at `Mio.` / `Mrd.`.

### Types of change
- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification
- [x] I ran `pytest` and all tests pass: **119 passed, 2 skipped**, Python 3.14.7. The two skips are optional spaCy component tests (spaCy not installed).
- [x] I ran `ruff format` and `ruff check --fix`; final `ruff check` and `ruff format src/ --check` pass. Unrelated formatter changes were excluded.
- [x] I have added tests for my changes.
- [x] My changes do not require public API documentation updates.

Before the rule changes, the added fixtures reproduced failures in both languages. Afterward, all 39 language-fixture tests pass, as does the full suite. Installed optional `langcodes` and `py3langid` locally to run their doctests. Also ran `scripts/reformat_sets.py` and `git diff --check`.

## Related Issues
Fixes #301.

## AI assistance
Prepared and validated with AI assistance.
