### PR TITLE
Add example for text chunking with sentence boundaries and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,13 @@ from yasbd.boundary_detector import BoundaryDetector
 detector = BoundaryDetector(lang="en")
 
 # With all options (so far.)
+# fmt: off
 detector = BoundaryDetector(
     # ISO 639 code (e.g., en, fr, es, ...). Required.
     # Use "auto" for automatic detection.
     # https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
     lang="fr",
+
     # Optional external language pack modules to load. Defaults to `None`.
     # Each pack is validated and stored in a private registry for this detector only.
     # Check #-lang-packs for more.
@@ -260,6 +262,7 @@ detector = BoundaryDetector(
     # Don't split inside them. (It won't protect block quotes) Defaults to `True`.
     # https://en.wikipedia.org/wiki/Block_quotation
     preserve_quote_and_paren=True,
+
     # Enable verbose logging. Defaults to `False`.
     verbose=True,
 )

--- a/README.md
+++ b/README.md
@@ -102,14 +102,15 @@ Nope!! It is a two-pass pipeline:
 
 Yasbd shines in real-world text processing scenarios where robust sentence boundaries matter, such as:
 
-- **📰 News & Article Processing**: Split news articles, blog posts, and journalism into sentences without mangling titles (`Dr.`, `Inc.`, `U.S.A.`) or breaking on decimals (`3.5M`, `$199.99`). Preserve complex citations (`Smith et al. (2021, pp. 128–129)`), section references (`Section 4.3(a)(ii)`), and URL query parameters without false splits.
-- **🤖 NLP Pipelines & Text Analytics**: Feed sentence-segmented text into tokenizers, named entity recognizers, or sentiment analyzers. Works as a fast, accurate preprocessor before parsing or embedding. Process 39 languages natively. Handle French compound abbreviations (`c.-à-d.`, `m.-à-j.`), Japanese quotes (`「...」`), and language-specific quirks automatically.
-- **📚 Document Chunking & RAG**: Split large documents into clean sentences for vector database ingestion, retrieval-augmented generation, or semantic search indexing. Preserves context boundaries in unstructured text.
-- **💬 Chat & Social Media Analysis**: Handle informal punctuation (`!!!`, `???`, `...`) and emoji reactions without fragmenting conversational intent. Perfect for chat logs, forum posts, and real-time messaging data.
-- **🌍 Multilingual NLP**: Process 39 languages natively. Handle French compound abbreviations (`c.-à-d.`, `m.-à-j.`), Japanese quotes (`「...」`), and language-specific quirks automatically.
-- **🧹 OCR & Noisy Text Cleanup**: Combine with `StreamCleaner` to fix OCR artifacts, mojibake, and HTML markup before segmentation. Ideal for PDF extraction and digitization workflows.
-- **🔗 spaCy Integration**: Use as a first-class spaCy pipeline component for fast, accurate sentence segmentation before dependency parsing or lemmatization.
-- **📦 CLI Text Processing**: Pipe documents directly into the command line for one-off batch segmentation without writing Python.
+- **📰 News & Article Processing**: Split articles without mangling titles (`Dr.`, `Inc.`), decimals (`3.5M`, `$199.99`), or citations (`Smith et al. (2021)`).
+- **🤖 NLP Pipelines & Text Analytics**: A fast preprocessor for tokenizers, NER, and sentiment analysis across 39 languages.
+- **📚 Document Chunking & RAG**: Clean sentence boundaries for vector database ingestion and retrieval-augmented generation.
+- **💬 Chat & Social Media Analysis**: Handles informal punctuation (`!!!`, `...`) and emoji without fragmenting conversational intent.
+- **🧹 OCR & Noisy Text Cleanup**: Combine with `StreamCleaner` to fix artifacts and mojibake before segmentation.
+- **📦 CLI Text Processing**: Pipe documents into the command line for one-off batch segmentation.
+
+> [!TIP]
+> Want it in action? Browse [`examples/`](examples/).
 
 ---
 
@@ -252,16 +253,13 @@ detector = BoundaryDetector(
     # Use "auto" for automatic detection.
     # https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
     lang="fr",
-
     # Optional external language pack modules to load. Defaults to `None`.
     # Each pack is validated and stored in a private registry for this detector only.
     # Check #-lang-packs for more.
     external_lang_packs=["yasbd_auxlang"],
-
     # Don't split inside them. (It won't protect block quotes) Defaults to `True`.
     # https://en.wikipedia.org/wiki/Block_quotation
     preserve_quote_and_paren=True,
-
     # Enable verbose logging. Defaults to `False`.
     verbose=True,
 )
@@ -322,16 +320,20 @@ Two detection modes:
 
 ```python
 # absolute mode (default)
-res= list(detector.detect('She turned to him, "This is great." She held the book out to show him.'))
+res = list(
+    detector.detect('She turned to him, "This is great." She held the book out to show him.')
+)
 print(res)
 # [35, 70]
 
 # relative mode with paragraph break
 detector.lang = "es"
-res = list(detector.detect(
-	"El Sr. García llegó ayer. La Sra. López también.\n\nVéase la pág. 55 del libro.",
-	relative=True,
-))
+res = list(
+    detector.detect(
+        "El Sr. García llegó ayer. La Sra. López también.\n\nVéase la pág. 55 del libro.",
+        relative=True,
+    )
+)
 print(res)
 # [25, 48, ParagraphEOF, 27]
 ```
@@ -349,10 +351,12 @@ print(res)
 # ['Hello world.', 'How are you?', 'I am fine.']
 
 # Multi-paragraph with whitespace preserved
-res = list(detector.segment(
-    "First para.\nStill first.\n\nSecond para.\nFinished.",
-    preserve_whitespace=True,
-))
+res = list(
+    detector.segment(
+        "First para.\nStill first.\n\nSecond para.\nFinished.",
+        preserve_whitespace=True,
+    )
+)
 print(res)
 # ['First para.', '\nStill first.', '\n\n', 'Second para.', '\nFinished.']
 ```
@@ -524,7 +528,9 @@ from yasbd.utils.pysbd_adapter import Segmenter
 # Or from yasbd.Pysbd_adapter import Segmenter
 
 seg = Segmenter(language="ja")
-res = seg.segment('田中さんは「準備は完了しました」そう言って部屋を出た。U.S.A.の経済政策は非常に複雑です。')
+res = seg.segment(
+    "田中さんは「準備は完了しました」そう言って部屋を出た。U.S.A.の経済政策は非常に複雑です。"
+)
 print(res)
 # ['田中さんは「準備は完了しました」そう言って部屋を出た。', 'U.S.A.の経済政策は非常に複雑です。']
 ```

--- a/examples/text_chunking.py
+++ b/examples/text_chunking.py
@@ -1,0 +1,84 @@
+"""Chunk text into whole sentences for RAG retrieval.
+
+Character/token cutting splits ideas mid-thought and hurts retrieval.
+This example chunks by sentence so boundaries always land between
+sentences, with optional overlap to carry context across chunks.
+"""
+
+from yasbd import BoundaryDetector
+
+_detector = BoundaryDetector("en")
+
+def chunk_text(
+    text: str,
+    lang: str,
+    max_sentences: int,
+    overlap_percent: int | float
+):
+    """Split text into overlapping sentence chunks for retrieval.
+
+    Segments *text* into sentences with :class:`yasbd.BoundaryDetector`,
+    then slides a fixed-size window over the sentence list, keeping
+    ``overlap_percent`` of the sentences from the previous chunk at the
+    start of the next one. Chunk boundaries therefore always fall on real
+    sentence boundaries, and neighbouring chunks share context.
+
+    Args:
+        text: The raw document text to chunk.
+        lang: ISO language code passed to the boundary detector.
+        max_sentences: Number of sentences per chunk.
+        overlap_percent: Percentage of the window size to carry over
+            between consecutive chunks. Clamped so the stride never drops
+            below one sentence.
+
+    Returns:
+        A list of chunk strings. Each chunk is its sentences joined back
+        together without added separators, so the original surrounding
+        whitespace is preserved as-is.
+    """
+    if not text:
+        return []
+
+    _detector.lang = lang
+    sentences = list(_detector.segment(text, preserve_whitespace=True))
+
+    # Each sentence is a unit so we can apply a fixed size windows with overlap
+    overlap_num = (max_sentences * overlap_percent) // 100
+    stride = max(1, max_sentences - overlap_num)
+
+    chunks = [sentences[:max_sentences]] # First chunk from start
+    for idx in range(max_sentences, len(sentences), stride):
+        chunk = sentences[idx - overlap_num: idx + stride]
+        chunks.append(chunk)
+
+    # Join sentences within each sublist to form final string chunks
+    return ["".join(chunk) for chunk in chunks]
+
+
+# === Example usage ===
+if __name__ == "__main__":
+    import textwrap
+
+    sample_text = textwrap.dedent("""
+        She loves cooking. He studies AI. "You are a Dr." she said. The weather is great.
+        We play chess. Books are fun.
+        The Playlist contains:
+            - two videos
+            - one music
+        Robots are learning.
+        It's raining. Let's code. Mars is red. Sr. sleep is rare.
+        Consider item 1. This is a test.
+        The year is 2025. This is a good year.
+        The section is N.A.S.A. related.
+    """)
+
+    chunks = chunk_text(
+        sample_text,
+        lang="en",
+        max_sentences=7,
+        overlap_percent=20
+    )
+    for i, chunk in enumerate(chunks):
+        print(f"-- Chunk {i+1} --")
+        print(chunk)
+        print()

--- a/examples/text_chunking.py
+++ b/examples/text_chunking.py
@@ -9,12 +9,8 @@ from yasbd import BoundaryDetector
 
 _detector = BoundaryDetector("en")
 
-def chunk_text(
-    text: str,
-    lang: str,
-    max_sentences: int,
-    overlap_percent: int | float
-):
+
+def chunk_text(text: str, lang: str, max_sentences: int, overlap_percent: int | float):
     """Split text into overlapping sentence chunks for retrieval.
 
     Segments *text* into sentences with :class:`yasbd.BoundaryDetector`,
@@ -46,9 +42,9 @@ def chunk_text(
     overlap_num = (max_sentences * overlap_percent) // 100
     stride = max(1, max_sentences - overlap_num)
 
-    chunks = [sentences[:max_sentences]] # First chunk from start
+    chunks = [sentences[:max_sentences]]  # First chunk from start
     for idx in range(max_sentences, len(sentences), stride):
-        chunk = sentences[idx - overlap_num: idx + stride]
+        chunk = sentences[idx - overlap_num : idx + stride]
         chunks.append(chunk)
 
     # Join sentences within each sublist to form final string chunks
@@ -72,13 +68,8 @@ if __name__ == "__main__":
         The section is N.A.S.A. related.
     """)
 
-    chunks = chunk_text(
-        sample_text,
-        lang="en",
-        max_sentences=7,
-        overlap_percent=20
-    )
+    chunks = chunk_text(sample_text, lang="en", max_sentences=7, overlap_percent=20)
     for i, chunk in enumerate(chunks):
-        print(f"-- Chunk {i+1} --")
+        print(f"-- Chunk {i + 1} --")
         print(chunk)
         print()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ ignore = ["PLW2901", "COM812", "D203", "D213", "RUF001", "RUF003", "RUF012", "S3
 "src/yasbd/utils/*.py" = ["E501", "BLE001", "FBT001", "FBT002", "PLR2004"]
 "tests/*" = ["E501", "S101", "PLR2004", "Q0", "ERA001", "SLF001", "PT006", "ARG002"]
 "benchmarks/*" = ["E501", "FBT001", "FBT002", "PLR2004", "BLE001", "INP001"]
+"examples/*" = ["INP001"]
 
 [tool.ruff.format]
 exclude = [".git", ".venv", "build", "dist", "tests/*.py", "*/EN_GOLDEN_DATA.py"]


### PR DESCRIPTION
## Objective

Add a runnable, self-contained example showing how to chunk documents for RAG using yasbd's sentence boundaries, and trim the README use-cases list that links to the new examples directory.

## Changes

- Added `examples/text_chunking.py`: segments text into sentences with `BoundaryDetector` (`preserve_whitespace=True`), then slides a fixed-size window over the sentence list with configurable percentage overlap, returning chunks whose boundaries always land between whole sentences.
- Trimmed the README "Use Cases" list and added a `[!TIP]` pointing at the `examples/` directory.
- Added `examples/*` to ruff's `INP001` per-file ignore (matches the `benchmarks/*` pattern).

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [x] Other (please describe): Community Example

## Verification

- [x] `ruff check` passes on the new file.
- [x] Example runs end-to-end (`python examples/text_chunking.py`), verified locally.
- [x] No tests added — standalone example script.

### Related issues
#294 