### PR TITLE
Add streaming TTS example with parallel generation and boundary detection

### DIFF
--- a/examples/asr_transcript_segmentation.py
+++ b/examples/asr_transcript_segmentation.py
@@ -42,7 +42,7 @@ def main() -> None:
     for i, sentence in enumerate(sentences, start=1):
         print(f"{i}: {sentence}")
 
-    assert sentences == EXPECTED_SENTENCES, (
+    assert sentences == EXPECTED_SENTENCES, (  # noqa: S101
         f"Segmentation drifted from the expected transcript sentences. Got: {sentences}"
     )
     print("\nOK: transcript segmented into complete sentences as expected.")

--- a/examples/live_tts.py
+++ b/examples/live_tts.py
@@ -6,11 +6,12 @@ Prerequisites:
 """
 
 import asyncio
-import os
 import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
 
+import aiofiles
 import edge_tts
 import miniaudio
 
@@ -36,10 +37,7 @@ class LiveTTS:
 
         if exception:
             error_msg = str(exception)
-            if (
-                "Connection lost" in error_msg
-                and "Connection reset by peer" in error_msg
-            ):
+            if "Connection lost" in error_msg and "Connection reset by peer" in error_msg:
                 return
 
         if "SSL handshake failed" in message or "SSLWantReadError" in message:
@@ -49,7 +47,7 @@ class LiveTTS:
 
     def _generate_tts_sync(self, text: str) -> str:
         """Generate TTS for a single sentence and save to temp file."""
-        tmp_file = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)  # noqa: SIM115
         tmp_file_path = tmp_file.name
         tmp_file.close()
 
@@ -97,7 +95,7 @@ class LiveTTS:
             for audio_file in executor.map(self._generate_tts_sync, chunks):
                 if audio_file:
                     self._play_audio(audio_file)
-                    os.remove(audio_file)
+                    Path(audio_file).unlink()
 
 
 # Example usage

--- a/examples/live_tts.py
+++ b/examples/live_tts.py
@@ -1,0 +1,116 @@
+"""
+Generates and plays Edge TTS audio sentence-by-sentence with parallel generation.
+
+Prerequisites:
+    pip install miniaudio, edge_tts
+"""
+
+import asyncio
+import os
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import edge_tts
+import miniaudio
+
+from yasbd import BoundaryDetector
+
+
+class LiveTTS:
+    def __init__(self, voice: str = "en-US-AriaNeural", n_jobs: int = 3) -> None:
+        """
+        Initialize the streaming client.
+
+        Args:
+            voice (str): Edge TTS voice model name
+            n_jobs (int, optional): Number of parallel TTS generation jobs
+        """
+        self.voice = voice
+        self.n_jobs = n_jobs
+
+    def _handle_async_exception(self, loop, context) -> None:
+        """Custom exception handler for async event loop."""
+        exception = context.get("exception")
+        message = context.get("message", "")
+
+        if exception:
+            error_msg = str(exception)
+            if "Connection lost" in error_msg and "Connection reset by peer" in error_msg:
+                return
+
+        if "SSL handshake failed" in message or "SSLWantReadError" in message:
+            return
+
+        loop.default_exception_handler(context)
+
+    def _generate_tts_sync(self, text: str) -> str:
+        """Generate TTS for a single sentence and save to temp file."""
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".mp3", delete=False)
+        tmp_file_path = tmp_file.name
+        tmp_file.close()
+
+        async def generate():
+            communicate = edge_tts.Communicate(
+                text, self.voice, rate="+15%"
+            )  # For slight energy boost
+
+            with open(tmp_file_path, "wb") as file:
+                async for chunk in communicate.stream():
+                    if chunk["type"] == "audio":
+                        file.write(chunk["data"])
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.set_exception_handler(self._handle_async_exception)
+        try:
+            loop.run_until_complete(generate())
+            return tmp_file_path
+        finally:
+            loop.close()
+
+    def _play_audio(self, file_path: str) -> None:
+        """Play audio file using miniaudio."""
+        stream = miniaudio.stream_file(file_path)
+        device = miniaudio.PlaybackDevice()
+        device.start(stream)
+
+        info = miniaudio.get_file_info(file_path)
+        time.sleep(info.duration)
+
+        device.close()
+
+    def play_live(self, text: str) -> None:
+        """
+        Generate and play text live (sentence-by-sentence).
+
+        Args:
+            text: Raw text to synthesize and play
+        """
+        splitter = BoundaryDetector(lang=self.voice.split("-")[0])
+        chunks = splitter.segment(text)
+
+        with ThreadPoolExecutor(max_workers=self.n_jobs) as executor:
+            for audio_file in executor.map(self._generate_tts_sync, chunks):
+                if audio_file:
+                    self._play_audio(audio_file)
+                    os.remove(audio_file)
+
+
+# Example usage
+if __name__ == "__main__":
+    import textwrap
+
+    text = textwrap.dedent("""
+        Got it. I updated my memory:
+        PLASMA is no longer an active project for you.
+        Ruff is your preferred Python tooling instead of Black, Pylint, and Flake8.
+        You mainly use PocketPal and MNN Chat for AI/local model usage.
+        Layla AI Lite is no longer considered one of your main tools.
+        I'll use these preferences going forward.
+    """)
+
+    client = LiveTTS(voice="en-US-AriaNeural", n_jobs=3)
+    print(text)
+    client.play_live(text)
+    print("Playback finished!")

--- a/examples/live_tts.py
+++ b/examples/live_tts.py
@@ -18,13 +18,13 @@ from yasbd import BoundaryDetector
 
 
 class LiveTTS:
-    def __init__(self, voice: str = "en-US-AriaNeural", n_jobs: int = 3) -> None:
+    def __init__(self, voice: str = "en-US-AriaNeural", n_jobs: int = 4) -> None:
         """
         Initialize the streaming client.
 
         Args:
-            voice (str): Edge TTS voice model name
-            n_jobs (int, optional): Number of parallel TTS generation jobs
+            voice: Edge TTS voice model name
+            n_jobs: Number of parallel TTS generation jobs
         """
         self.voice = voice
         self.n_jobs = n_jobs

--- a/examples/live_tts.py
+++ b/examples/live_tts.py
@@ -2,7 +2,7 @@
 Generates and plays Edge TTS audio sentence-by-sentence with parallel generation.
 
 Prerequisites:
-    pip install miniaudio, edge_tts
+    pip install miniaudio, edge_tts, aiofiles
 """
 
 import asyncio
@@ -36,7 +36,10 @@ class LiveTTS:
 
         if exception:
             error_msg = str(exception)
-            if "Connection lost" in error_msg and "Connection reset by peer" in error_msg:
+            if (
+                "Connection lost" in error_msg
+                and "Connection reset by peer" in error_msg
+            ):
                 return
 
         if "SSL handshake failed" in message or "SSLWantReadError" in message:
@@ -55,10 +58,10 @@ class LiveTTS:
                 text, self.voice, rate="+15%"
             )  # For slight energy boost
 
-            with open(tmp_file_path, "wb") as file:
+            async with aiofiles.open(tmp_file_path, "wb") as file:
                 async for chunk in communicate.stream():
                     if chunk["type"] == "audio":
-                        file.write(chunk["data"])
+                        await file.write(chunk["data"])
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)


### PR DESCRIPTION
## Objective

Add a self-contained streaming TTS example that demonstrates sentence-by-sentence audio playback using Edge TTS with parallel generation, showcasing yasbd's boundary detection for natural speech segmentation.

## Changes

- Added `examples/live_tts.py`: segments input text with `BoundaryDetector`, generates TTS audio for each sentence in parallel using `ThreadPoolExecutor`, and plays audio sequentially with `miniaudio`.
- Implemented `LiveTTS` class with configurable voice and parallel job count.
- Added custom async exception handler to gracefully manage Edge TTS connection/SSL errors.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [x] Other (please describe): Community Example

## Verification

- [x] `ruff check` passes on the new file.
- [x] Example runs end-to-end (`python examples/live_tts.py`), verified locally.
- [x] No tests added. Just a standalone example script.

### Related issues
#294