### PR TITLE
Fix markdown header splitting for numbered headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Unicode newline-inside-sentence detection** ([#276](https://github.com/speedyk-005/yasbd-lib/pull/276)): `NEWLINE_INSIDE_SENTENCE_FINDER` now uses the Unicode lowercase property `\p{Ll}` instead of ASCII-only `[a-z]`, so newlines before Cyrillic and other non-ASCII lowercase letters are no longer treated as sentence boundaries.
 - **Russian abbreviation coverage** ([#278](https://github.com/speedyk-005/yasbd-lib/pull/278)): Expanded `TITLE_ABBRVS`, `REFERENCE_ABBRVS`, and `INLINE_ONLY_ABBRVS` with missing Russian abbreviations, and added Cyrillic initial-chain handling to `MID_SENTENCE_FINDER_LST` to prevent false splits (e.g., `Арх. Иванов` and `Проф. Петров А.К.`).
 - **List boundary ordering** ([#277](https://github.com/speedyk-005/yasbd-lib/pull/277)): Run list boundary adjustment before mid-sentence filtering to prevent re-adding boundaries suppressed by abbreviation handling (e.g., `И т. д.` no longer splits).
+- **Markdown numbered headers** ([#306](https://github.com/speedyk-005/yasbd-lib/pull/306)): Markdown headings with trailing numbers (e.g., `### 1. The Regex Breakdown`) are kept whole instead of being split into `### 1.` and the header title.
 
 ---
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -323,11 +323,15 @@ class Rules:
                """, re.X
             ),
 
-            # structural headings (e.g., "Section 1. The Beginning.")
+            # Structural headings (e.g., "Chapter 1. The Beginning.")
+            # and markdown headers (e.g., "### 1. The Regex Breakdown").
             re.compile(rf"""
-                \b(?:{build_optimized_pattern(cls.SECTION_MARKERS)})\s+
+                (?:
+                    ^\#{{1,6}}\s*|
+                    \b(?:{build_optimized_pattern(cls.SECTION_MARKERS)})\s+
+                )
                 (?:[\dIVXLCDM]+{cls.DOTS_PATTERN}){{1,3}}
-                """, re.X
+                """, re.M | re.X
             )
         ]
 

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -157,6 +157,7 @@ def test_rule_cache_lru(en_detector):
     assert type(r_en) is type(r1), "freshly loaded en rule should exist"  # type: ignore[unreachable]
 
 
+# fmt: off
 @pytest.mark.parametrize(
     "marked_text",
     [
@@ -230,6 +231,7 @@ def test_universal_regression(en_detector, marked_text):
 
     result = list(en_detector.segment(input_text))
     assert result == expected, f"Input: {input_text}"
+# fmt: on
 
 
 def test_cyrillic_newline_inside_sentence():
@@ -240,14 +242,19 @@ def test_cyrillic_newline_inside_sentence():
     assert result[0].replace("\n", " ") == "Это слово продолжается."
 
 
+def test_markdown_numbered_headers_not_split():
+    """Test that markdown headers with trailing numbers stay whole (fix for #305)."""
+    detector = BoundaryDetector(lang="en")
+    result = list(detector.segment("### 1. The Regex Breakdown\n### 2. Metric Interpretation"))
+    assert result == ["### 1. The Regex Breakdown", "### 2. Metric Interpretation"]
+
+
 def test_post_processing_hook_supports_mutation():
     """test that a hook can remove and add boundaries in place."""
 
     def tweak(ctx):
         # Remove the boundary after "Hi." (join) and add one after "There" (split)
-        ctx["boundaries"] = [
-            pos for pos in ctx["boundaries"] if pos != 3
-        ] + [10]
+        ctx["boundaries"] = [pos for pos in ctx["boundaries"] if pos != 3] + [10]
 
     detector = BoundaryDetector(lang="en", hook=tweak)
     assert list(detector.segment("Hi. There world.")) == ["Hi. There", "world."]


### PR DESCRIPTION
## Objective

Markdown headings with trailing numbers (e.g., `### 1. The Regex Breakdown`) were being split into `### 1.` and `The Regex Breakdown`. Numbered markdown headers should stay whole.

## Changes

- Extended the structural-heading finder in `src/yasbd/rules/base.py` to also recognize markdown header tokens (`^#{1,6}`) followed by an optional number + period.
- Structural headings (e.g., `Chapter 1. The Beginning.`) continue to match unchanged.
- Added a regression test covering consecutive numbered markdown headers.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #305