### PR TITLE
Fix indented markdown headers in structural-heading finder (post)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Unicode newline-inside-sentence detection** ([#276](https://github.com/speedyk-005/yasbd-lib/pull/276)): `NEWLINE_INSIDE_SENTENCE_FINDER` now uses the Unicode lowercase property `\p{Ll}` instead of ASCII-only `[a-z]`, so newlines before Cyrillic and other non-ASCII lowercase letters are no longer treated as sentence boundaries.
 - **Russian abbreviation coverage** ([#278](https://github.com/speedyk-005/yasbd-lib/pull/278)): Expanded `TITLE_ABBRVS`, `REFERENCE_ABBRVS`, and `INLINE_ONLY_ABBRVS` with missing Russian abbreviations, and added Cyrillic initial-chain handling to `MID_SENTENCE_FINDER_LST` to prevent false splits (e.g., `Арх. Иванов` and `Проф. Петров А.К.`).
 - **List boundary ordering** ([#277](https://github.com/speedyk-005/yasbd-lib/pull/277)): Run list boundary adjustment before mid-sentence filtering to prevent re-adding boundaries suppressed by abbreviation handling (e.g., `И т. д.` no longer splits).
-- **Markdown numbered headers** ([#306](https://github.com/speedyk-005/yasbd-lib/pull/306)): Markdown headings with trailing numbers (e.g., `### 1. The Regex Breakdown`) are kept whole instead of being split into `### 1.` and the header title.
+- **Markdown numbered headers** ([#306](https://github.com/speedyk-005/yasbd-lib/pull/306)/[#307](https://github.com/speedyk-005/yasbd-lib/pull/307)): Markdown headings with trailing numbers (e.g., `### 1. The Regex Breakdown`) are kept whole instead of being split into `### 1.` and the header title.
 
 ---
 

--- a/src/yasbd/rules/base.py
+++ b/src/yasbd/rules/base.py
@@ -327,7 +327,7 @@ class Rules:
             # and markdown headers (e.g., "### 1. The Regex Breakdown").
             re.compile(rf"""
                 (?:
-                    ^\#{{1,6}}\s*|
+                    ^\s*\#{{1,6}}\s*|
                     \b(?:{build_optimized_pattern(cls.SECTION_MARKERS)})\s+
                 )
                 (?:[\dIVXLCDM]+{cls.DOTS_PATTERN}){{1,3}}

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -225,6 +225,7 @@ def test_rule_cache_lru(en_detector):
 
         # markdown headers with trailing numbers stay whole (fix for #305)
         "### 1. The Regex Breakdown\n|### 2. Metric Interpretation",
+        "        ### 1. The Regex Breakdown\n|        ### 2. Metric Interpretation",
     ],
 )
 def test_universal_regression(en_detector, marked_text):

--- a/tests/test_boundary_detector.py
+++ b/tests/test_boundary_detector.py
@@ -222,6 +222,9 @@ def test_rule_cache_lru(en_detector):
 
         # CORP_ENTITY_ABBRVS must use word boundary (fix regression)
         "Kid!| Don't buy tobacco.| Alright!",
+
+        # markdown headers with trailing numbers stay whole (fix for #305)
+        "### 1. The Regex Breakdown\n|### 2. Metric Interpretation",
     ],
 )
 def test_universal_regression(en_detector, marked_text):
@@ -240,13 +243,6 @@ def test_cyrillic_newline_inside_sentence():
     result = list(detector.segment("Это\nслово продолжается."))
     assert len(result) == 1
     assert result[0].replace("\n", " ") == "Это слово продолжается."
-
-
-def test_markdown_numbered_headers_not_split():
-    """Test that markdown headers with trailing numbers stay whole (fix for #305)."""
-    detector = BoundaryDetector(lang="en")
-    result = list(detector.segment("### 1. The Regex Breakdown\n### 2. Metric Interpretation"))
-    assert result == ["### 1. The Regex Breakdown", "### 2. Metric Interpretation"]
 
 
 def test_post_processing_hook_supports_mutation():


### PR DESCRIPTION
## Objective

Follow-up to #306: markdown headers with trailing numbers that are indented (e.g., inside code blocks or nested content) were still split into `### 1.` and `The Regex Breakdown`. The structural-heading finder anchored `#` to column 0, so any leading whitespace broke the match.

## Changes

- Extend the markdown-header alternative in the structural-heading finder (`src/yasbd/rules/base.py`) from `^#{1,6}` to `^\s*#{1,6}` so headers with leading whitespace are matched too.
- Structural headings (e.g., `Chapter 1. The Beginning.`) and flush-left markdown headers continue to match unchanged.
- Added an indented-header case to the existing markdown regression test.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #305 (incomplete fix shipped in #306)