### PR TITLE
Fix Swahili abbreviations Na. and Tsh. from splitting sentences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Swahili address and currency abbreviations** ([#310](https://github.com/speedyk-005/yasbd-lib/pull/310)): Added `na` and `tsh` to Swahili `REFERENCE_ABBRVS` so `Na.` (Namba) and `Tsh.` (Tanzanian shilling) do not trigger false sentence splits before numbers and currency amounts.
+
 - **Inline example abbreviations** ([#291](https://github.com/speedyk-005/yasbd-lib/pull/291)): Keep Hindi, Lithuanian, Malayalam, and Russian equivalents of "for example" from ending sentences.
 - **Afrikaans/Dutch title `Mev.`** ([#297](https://github.com/speedyk-005/yasbd-lib/pull/297)): Added the missing `mev` honorific to `TITLE_ABBRVS` in `nl.py`, which Afrikaans inherits, preventing false sentence splits after `Mev. Jansen` (e.g., `Mev. Jansen praat.` no longer splits after `Mev.`).
 - **Telephone and fax abbreviations** ([#284](https://github.com/speedyk-005/yasbd-lib/pull/284)): Treat `tel.` and `fax.` as shared reference abbreviations before contact numbers across language profiles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.3] - 2026-09-09
+## [Unreleased]
 
 ### Fixed
 
 - **Swahili address and currency abbreviations** ([#310](https://github.com/speedyk-005/yasbd-lib/pull/310)): Added `na` and `tsh` to Swahili `REFERENCE_ABBRVS` so `Na.` (Namba) and `Tsh.` (Tanzanian shilling) do not trigger false sentence splits before numbers and currency amounts.
+
+---
+
+## [0.16.3] - 2026-09-09
+
+### Fixed
 
 - **Inline example abbreviations** ([#291](https://github.com/speedyk-005/yasbd-lib/pull/291)): Keep Hindi, Lithuanian, Malayalam, and Russian equivalents of "for example" from ending sentences.
 - **Afrikaans/Dutch title `Mev.`** ([#297](https://github.com/speedyk-005/yasbd-lib/pull/297)): Added the missing `mev` honorific to `TITLE_ABBRVS` in `nl.py`, which Afrikaans inherits, preventing false sentence splits after `Mev. Jansen` (e.g., `Mev. Jansen praat.` no longer splits after `Mev.`).

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@cnaples79](https://github.com/cnaples79)** | Missing comma in set literals fix |
 | **[@ColumbusLabs](https://github.com/ColumbusLabs)** | Preserve word boundaries across StreamCleaner line breaks |
 | **[@ddelrio1986](https://github.com/ddelrio1986)** | Spelling and grammar fixes in docs |
+| **[@DYNOSuprovo](https://github.com/DYNOSuprovo)** | Swahili address and currency abbreviations (`Na.`, `Tsh.`) fix |
 | **[@HeaTTap](https://github.com/HeaTTap)** | Line ending normalization in default cleaning pipeline; removed destructive slash normalization from StreamCleaner |
 | **[@hkJerryLeung](https://github.com/hkJerryLeung)** | French `est` abbreviation fix |
 | **[@hongquan](https://github.com/hongquan)** | `py.typed` marker for PEP 561 compliance |

--- a/src/yasbd/rules/sw.py
+++ b/src/yasbd/rules/sw.py
@@ -14,7 +14,7 @@ class SwRules(Rules):
     }
 
     REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
-        "uk", "sur", "jal", "har", "mf", "t.m", "n.k",
+        "uk", "sur", "jal", "har", "mf", "t.m", "n.k", "na", "tsh",
     }
 
     INLINE_ONLY_ABBRVS = Rules.INLINE_ONLY_ABBRVS | {

--- a/tests/test_data/swahili.py
+++ b/tests/test_data/swahili.py
@@ -14,6 +14,7 @@ TEST_DATA = [
     "Mj. wa Kamati alitoa taarifa.| Kamati ilikubali.",
     "Dkt. Mwangi atawasili kesho.| Ana mkutano saa tatu.",
     "Mwl. Hassan anafundisha Kiswahili.| Wanafunzi wanamwapenda.",
+    "Anaishi Mtaa wa Uhuru Na. 15.| Rafiki yake anaishi Na. 17.| Bei ni Tsh. 10,000.| Hiyo ni ghali sana.",
 
     # Structural headings
     "Sura ya 1. Utangulizi.| Ilikuwa usiku wa giza.",


### PR DESCRIPTION
## Objective

Keep Swahili reference abbreviations `Na.` (*Namba*, number) and `Tsh.` (Tanzanian shilling) from being treated as sentence boundaries when followed by numeric address indicators or currency values.

## Changes

- Added `"na"` and `"tsh"` to `SwRules.REFERENCE_ABBRVS` in `src/yasbd/rules/sw.py`.
- Added regression test cases covering `Na.` and `Tsh.` to `tests/test_data/swahili.py`.
- Added contributor entry in `CONTRIBUTORS.md`.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass (94/94 test cases pass, including all 39 language profiles in `test_segment_multiple_langs`).
- [x] I ran `ruff format . && ruff check --fix .` (clean, no warnings).
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #309
