### PR TITLE
Preserve Swahili abbreviations Na. and Tsh. in text processing

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,5 +31,6 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@terminalchai](https://github.com/terminalchai)** | Burmese and Thai reporting words fix |
 | **[@XEDAB](https://github.com/XEDAB)** | Replaced manual adjacent boundary iteration with `itertools.pairwise` |
 | **[@YuEfSaEDU](https://github.com/YuEfSaEDU)** | Afrikaans/Dutch title `Mev.` abbreviation fix |
+| **[@krsnak](https://github.com/krsnak)** | Swahili `Na.` and `Tsh.` reference abbreviation boundary fix |
 
 Interested in contributing? See the [**Contributing Guide**](CONTRIBUTING.md) to get started!

--- a/src/yasbd/rules/sw.py
+++ b/src/yasbd/rules/sw.py
@@ -14,7 +14,7 @@ class SwRules(Rules):
     }
 
     REFERENCE_ABBRVS = Rules.REFERENCE_ABBRVS | {
-        "uk", "sur", "jal", "har", "mf", "t.m", "n.k",
+        "uk", "sur", "jal", "har", "mf", "t.m", "n.k", "na", "tsh",
     }
 
     INLINE_ONLY_ABBRVS = Rules.INLINE_ONLY_ABBRVS | {

--- a/tests/test_data/swahili.py
+++ b/tests/test_data/swahili.py
@@ -14,6 +14,8 @@ TEST_DATA = [
     "Mj. wa Kamati alitoa taarifa.| Kamati ilikubali.",
     "Dkt. Mwangi atawasili kesho.| Ana mkutano saa tatu.",
     "Mwl. Hassan anafundisha Kiswahili.| Wanafunzi wanamwapenda.",
+    "Anaishi Mtaa wa Uhuru Na. 15.| Rafiki yake anaishi Na. 17.| "
+    "Bei ni Tsh. 10,000.| Hiyo ni ghali sana.",
 
     # Structural headings
     "Sura ya 1. Utangulizi.| Ilikuwa usiku wa giza.",


### PR DESCRIPTION
## Objective

Prevent Swahili reference abbreviations `Na.` (Namba) and `Tsh.` (Tanzanian shilling) from being treated as sentence boundaries.

## Changes

- Added `na` and `tsh` to the Swahili `REFERENCE_ABBRVS` set.
- Added regression coverage for `Na. 15`, `Na. 17`, and `Tsh. 10,000` using the existing Swahili test data.
- Added `@krsnak` to `CONTRIBUTORS.md` as required by the contribution guide.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

Validation result: 121 passed, 2 skipped; 1043 subtests passed; total coverage 95%.

## Related Issues

- Fixes #309