### PR TITLE
Fix German/Dutch abbreviations causing sentence splits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **German and Dutch unit/reference abbreviations** ([#301](https://github.com/speedyk-005/yasbd-lib/issues/301)): Added `Mio` and `Mrd` to German `INLINE_ONLY_ABBRVS`, and Dutch `mln`, `m.b.t`, `zgn` to `INLINE_ONLY_ABBRVS` and `d.d` to `REFERENCE_ABBRVS` to prevent false sentence splits.
 - **Swahili address and currency abbreviations** ([#310](https://github.com/speedyk-005/yasbd-lib/pull/310)): Added `na` and `tsh` to Swahili `REFERENCE_ABBRVS` so `Na.` (Namba) and `Tsh.` (Tanzanian shilling) do not trigger false sentence splits before numbers and currency amounts.
 
 ---

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,7 +11,7 @@ A massive thank you to the open source community helping make `yasbd` more accur
 | **[@cnaples79](https://github.com/cnaples79)** | Missing comma in set literals fix |
 | **[@ColumbusLabs](https://github.com/ColumbusLabs)** | Preserve word boundaries across StreamCleaner line breaks |
 | **[@ddelrio1986](https://github.com/ddelrio1986)** | Spelling and grammar fixes in docs |
-| **[@DYNOSuprovo](https://github.com/DYNOSuprovo)** | Swahili address and currency abbreviations (`Na.`, `Tsh.`) fix |
+| **[@DYNOSuprovo](https://github.com/DYNOSuprovo)** | Swahili (`Na.`, `Tsh.`) and German/Dutch unit/reference abbreviations fix |
 | **[@HeaTTap](https://github.com/HeaTTap)** | Line ending normalization in default cleaning pipeline; removed destructive slash normalization from StreamCleaner |
 | **[@hkJerryLeung](https://github.com/hkJerryLeung)** | French `est` abbreviation fix |
 | **[@hongquan](https://github.com/hongquan)** | `py.typed` marker for PEP 561 compliance |

--- a/src/yasbd/rules/de.py
+++ b/src/yasbd/rules/de.py
@@ -49,6 +49,9 @@ class DeRules(Rules):
         "bzw", "evtl", "ggf", "ggfs", "inkl", "sog",
         "zzgl", "bspw", "insb", "ca", "bsp",
 
+        # Units and Quantifiers
+        "Mio", "Mrd",
+
         # Business/Commercial
         "fa",
     }

--- a/src/yasbd/rules/nl.py
+++ b/src/yasbd/rules/nl.py
@@ -31,7 +31,7 @@ class NlRules(DeRules):
         "bijl", "ca", "cf", "ed", "vert", "id",
 
         # Legal, Corporate, and Formal Citation Markers
-        "b.w", "gem", "coll", "hr", "c.q", "ov", "vp",
+        "b.w", "gem", "coll", "hr", "c.q", "ov", "vp", "d.d",
     }
 
     SECTION_MARKERS = Rules.SECTION_MARKERS | {
@@ -42,7 +42,7 @@ class NlRules(DeRules):
 
     INLINE_ONLY_ABBRVS = DeRules.INLINE_ONLY_ABBRVS | {
         "bijv", "ca", "d.w.z", "e.v.t.l", "excl", "incl",
-        "z.g.n",
+        "z.g.n", "mln", "m.b.t", "zgn",
     }
 
     DATE_ABBRVS = Rules.DATE_ABBRVS | {

--- a/tests/test_data/dutch.py
+++ b/tests/test_data/dutch.py
@@ -21,6 +21,10 @@ TEST_DATA = [
     "We kiezen eerst optie A.| Daarna bespreken we de details.",
     "De vergadering begint om 14.| Vandaag bespreken we de details.",
     "Mev. Jansen spreekt met dhr. Bakker.| Mevr. De Vries komt later langs.",
+    "Jan d.d. 10-03-2020 tekende het contract.| Piet deed dat niet.",
+    "Zie m.b.t. 2024 het jaarverslag.| Alles staat erin.",
+    "zgn. Eind 18 wordt vervangen.| Niemand weet het.",
+    "De totale omzet bedroeg 5 mln. euro.| Dat is veel.",
 
     # Structural headings
     "Hoofdstuk 1. Het begin.| Het was donker en stil in de kamer.| Niets bewoog.",

--- a/tests/test_data/german.py
+++ b/tests/test_data/german.py
@@ -20,6 +20,9 @@ TEST_DATA = [
     "Sie finden es unter Nr. 1026.253.553.| Dort ist der Schatz.",
     "Wir wählen zuerst Option A.| Danach besprechen wir die Details.",
     "Rufen Sie Tel. 555-0199 an.| Senden Sie ein Fax. 02-555 morgen.",
+    "Die Kosten betrugen etwa 5 Mio. Euro.| Das ist viel.",
+    "Deutschland hat 83 Mio. Einwohner.| Das sind frische Zahlen.",
+    "Das Unternehmen erzielte 2 Mrd. Euro Umsatz.| Ein neuer Rekord.",
 
     # Structural headings
     "Kapitel 1. Der Anfang.| Es war dunkel und still im Raum. | Nichts bewegte sich.",


### PR DESCRIPTION
﻿## Objective

Common German and Dutch unit/reference abbreviations (`Mio.`, `Mrd.` in German; `d.d.`, `m.b.t.`, `zgn.`, `mln.` in Dutch) were missing from their respective rule profiles, causing false sentence splits mid-sentence (especially before capitalized German nouns and Dutch dates/numbers).

## Changes

- **`src/yasbd/rules/de.py`**: Added `Mio` and `Mrd` to `INLINE_ONLY_ABBRVS` so `Mio.` and `Mrd.` stay inline when preceding capitalized common nouns and units.
- **`src/yasbd/rules/nl.py`**:
  - Added `d.d` to `REFERENCE_ABBRVS` so dates following `d.d.` do not split.
  - Added `mln`, `m.b.t`, and `zgn` to `INLINE_ONLY_ABBRVS` so connectors and units do not end clauses.
- **`tests/test_data/german.py`**: Added test cases for `Mio.` and `Mrd.`.
- **`tests/test_data/dutch.py`**: Added test cases for `d.d.`, `m.b.t.`, `zgn.`, and `mln.`.
- **`CHANGELOG.md`**: Documented changes under `[Unreleased] -> Fixed`.
- **`CONTRIBUTORS.md`**: Updated contribution entry for `@DYNOSuprovo`.

### Types of change

- [x] Bug fix (non-breaking change fixing an issue)

## Verification

- [x] I ran `pytest` and all tests pass (112 passed, 2 skipped, 1050 subtests passed).
- [x] I ran `ruff format . && ruff check --fix .` (0 errors).
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #301
