### PR TITLE
Remove loguru dependency to reduce runtime footprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Remove loguru dependency** ([#316](https://github.com/speedyk-005/yasbd-lib/pull/316)): Replace loguru with a custom stdlib logger in `utils/logger.py`.
+- **Remove loguru dependency** ([#317](https://github.com/speedyk-005/yasbd-lib/pull/317)): Replace loguru with a custom stdlib logger in `utils/logger.py`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Swahili address and currency abbreviations** ([#310](https://github.com/speedyk-005/yasbd-lib/pull/310)): Added `na` and `tsh` to Swahili `REFERENCE_ABBRVS` so `Na.` (Namba) and `Tsh.` (Tanzanian shilling) do not trigger false sentence splits before numbers and currency amounts.
 - **Persian and Arabic hierarchical section numbers** ([#315](https://github.com/speedyk-005/yasbd-lib/pull/315)): Prevent splits after hierarchical numbers like `1٫2.` via mid-sentence regex.
 
+### Changed
+
+- **Remove loguru dependency** ([#316](https://github.com/speedyk-005/yasbd-lib/pull/316)): Replace loguru with a custom stdlib logger in `utils/logger.py`.
+
 ---
 
 ## [0.16.3] - 2026-09-09

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ keywords = [
 ]
 
 dependencies = [
-  "loguru>=0.7.3,<1.0",
   "regex>=2024.11.6",
   "ftfy>=6.2.0,<7.0",
   "retrie>=0.3.0,<0.4",

--- a/src/yasbd/utils/logger.py
+++ b/src/yasbd/utils/logger.py
@@ -18,7 +18,9 @@ def log_info(verbose: bool, message: str, *args, **kwargs) -> None:
         **kwargs: Keyword arguments passed to logger.info().
 
     Example:
-        >>> log_info(True, "hello {}", "world")
+        >>> log_info(True, "hello {}", "world")  # doctest: +ELLIPSIS
+        \033...-... - hello world
+
         >>> log_info(False, "This will not be logged")
     """
     if not verbose:

--- a/src/yasbd/utils/logger.py
+++ b/src/yasbd/utils/logger.py
@@ -1,7 +1,12 @@
-from loguru import logger
+import sys
+from datetime import datetime
+
+GREEN = "\033[32m"
+CYAN = "\033[36m"
+RESET = "\033[0m"
 
 
-def log_info(verbose: bool, *args, **kwargs) -> None:
+def log_info(verbose: bool, message: str, *args, **kwargs) -> None:
     """Log an info message if verbose is enabled.
 
     This is a convenience function that only logs when verbose mode is enabled,
@@ -16,5 +21,16 @@ def log_info(verbose: bool, *args, **kwargs) -> None:
         >>> log_info(True, "hello {}", "world")
         >>> log_info(False, "This will not be logged")
     """
-    if verbose:
-        logger.info(*args, **kwargs)
+    if not verbose:
+        return
+
+    frame = sys._getframe(1)  # noqa: SLF001
+
+    module = frame.f_globals.get("__name__", "__main__")
+    function = frame.f_code.co_name
+    line = frame.f_lineno
+
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+    message = message.format(*args, **kwargs)
+
+    print(f"{GREEN}{now}{RESET} | {CYAN}{module}:{function}:{line}{RESET} - {message}")


### PR DESCRIPTION
## Objective

Remove the `loguru` dependency which is only used for a single `log_info` helper, reducing runtime footprint.

## Changes

- Replace `src/yasbd/utils/logger.py` `loguru` implementation with a custom stdlib logger using `datetime` + `sys._getframe(1)` with ANSI codes preserving `log_info(verbose, ...)` API.
- Remove `loguru>=0.7.3,<1.0` from `pyproject.toml` dependencies.
- Update `CHANGELOG.md`

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [ ] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.

## Related Issues

- Fixes #287
