### PR TITLE
Remove beartype dependency and replace with stdlib validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Remove loguru dependency** ([#317](https://github.com/speedyk-005/yasbd-lib/pull/317)): Replace loguru with a custom stdlib logger in `utils/logger.py`.
+- **Remove dependencies**:
+  - loguru ([#317](https://github.com/speedyk-005/yasbd-lib/pull/317)): Replace loguru with a custom stdlib logger in `utils/logger.py`.
+  - beartype ([#318](https://github.com/speedyk-005/yasbd-lib/pull/318)): Replace beartype with a partial stdlib validator in `utils/input_validator.py`.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "ftfy>=6.2.0,<7.0",
   "retrie>=0.3.0,<0.4",
   "radicli>=0.0.26,<0.0.27",
-  "beartype>=0.22,<0.23",
 ]
 
 [project.optional-dependencies]

--- a/src/yasbd/utils/input_validator.py
+++ b/src/yasbd/utils/input_validator.py
@@ -32,28 +32,32 @@ def _trunc_repr(value):  # pragma: no cover
 
 def _validate_type(value, expected_type, name):
     """Validate a value against an expected type."""
-    if expected_type is None or expected_type is type(None):
+    # Origin first: `isinstance(hint, type)` is version-flaky for generics
+    # (e.g. `type[X]` passes it on 3.10), so never let them reach that gate.
+    origin = typing.get_origin(expected_type)
+    if origin is UnionType or origin is typing.Union:
+        valid = False
+        for option in typing.get_args(expected_type):
+            try:
+                _validate_type(value, option, name)
+                valid = True
+                break
+            except InvalidInputError:
+                continue
+    elif origin is type:
+        args = typing.get_args(expected_type)
+        valid = isinstance(value, type) and (not args or issubclass(value, args[0]))
+    elif origin is not None:
+        valid = isinstance(value, origin)
+    elif expected_type is None or expected_type is type(None):
         valid = value is None
     elif isinstance(expected_type, type):
         valid = isinstance(value, expected_type)
     else:
-        origin = typing.get_origin(expected_type)
-        if origin is UnionType or origin is typing.Union:
-            valid = False
-            for option in typing.get_args(expected_type):
-                try:
-                    _validate_type(value, option, name)
-                    valid = True
-                    break
-                except InvalidInputError:
-                    continue
-        elif origin is type:
-            args = typing.get_args(expected_type)
-            valid = isinstance(value, type) and (not args or issubclass(value, args[0]))
-        elif origin is not None:
-            valid = isinstance(value, origin)
-        else:
+        try:
             valid = isinstance(value, expected_type)
+        except TypeError:
+            valid = True
 
     if valid:
         return value

--- a/src/yasbd/utils/input_validator.py
+++ b/src/yasbd/utils/input_validator.py
@@ -1,25 +1,122 @@
+"""Partial runtime type validation for public entry points.
+
+This module intentionally covers only what yasbd uses: plain types,
+``None``, unions (``X | Y``), and subscripted generics checked via their
+origin (e.g. ``Collection[str]`` validates as ``collections.abc.Collection``
+without checking element types). Exotic forms (``Literal``, ``Annotated``,
+``TypeVar``, nested parameters) are accepted unchecked rather than rejected.
+
+It is a lightweight beartype replacement, not a full type checker: when in
+doubt it passes the value through instead of raising.
+"""
+
+import reprlib
+import typing
 from collections.abc import Callable
 from functools import wraps
-from typing import TypeVar
-
-from beartype import beartype
-from beartype.roar import BeartypeCallHintViolation
+from types import UnionType
 
 from yasbd.exceptions import InvalidInputError
 
-F = TypeVar("F", bound=Callable)
+F = typing.TypeVar("F", bound=Callable)
 
 
-def validate_input(fn: F) -> F:
-    """Validate function arguments and return values using beartype."""
+def _trunc_repr(value):  # pragma: no cover
+    """Truncate values for readable error messages."""
+    # Use reprlib for auto-truncation on non-strings
+    # (faster for lists/dicts/nested)
+    if isinstance(value, str) and len(value) >= 120:
+        return value[:500] + "..."
+    return reprlib.repr(value)
 
-    validated_fn = beartype(fn)
 
-    @wraps(fn)
+def _validate_type(value, expected_type, name):
+    """Validate a value against an expected type."""
+    if expected_type is None or expected_type is type(None):
+        valid = value is None
+    elif isinstance(expected_type, type):
+        if isinstance(value, type):
+            valid = issubclass(value, expected_type)
+        else:
+            valid = isinstance(value, expected_type)
+    else:
+        origin = typing.get_origin(expected_type)
+        if origin is UnionType or origin is typing.Union:
+            valid = False
+            for option in typing.get_args(expected_type):
+                try:
+                    _validate_type(value, option, name)
+                    valid = True
+                    break
+                except InvalidInputError:
+                    continue
+        elif origin is not None:
+            valid = isinstance(value, origin)
+        else:
+            valid = isinstance(value, expected_type)
+
+    if valid:
+        return value
+
+    raise InvalidInputError(
+        f"Invalid type for {name!r}.\n"
+        f"Expected {expected_type}.\n"
+        f"Found: (input={_trunc_repr(value)}, type={type(value).__name__!r})"
+    )
+
+
+def _validate_call(pos_checks, kw_checks, args, kwargs):
+    """Validate call arguments in place (validators never transform values)."""
+    # Validate positional-or-keyword arguments
+    for idx, name, expected_type in pos_checks:
+        if idx < len(args):
+            _validate_type(args[idx], expected_type, name=name)
+        elif name in kwargs:
+            _validate_type(kwargs[name], expected_type, name=name)
+
+    # Validate keyword-only arguments
+    for name, expected_type in kw_checks:
+        if name in kwargs:
+            _validate_type(kwargs[name], expected_type, name=name)
+
+
+def validate_input(fx: F) -> F:
+    """Validate function arguments based on  type hints."""
+    hints = typing.get_type_hints(fx)
+    ret_type = hints.pop("return", None)
+
+    if not hints and ret_type is None:
+        return fx
+
+    # Pre-compute positional param indices (skip self)
+    code = fx.__code__
+    varnames = code.co_varnames
+    argcount = code.co_argcount
+    kwonlycount = code.co_kwonlyargcount
+
+    pos_names = varnames[:argcount]
+    kwonly_names = varnames[argcount : argcount + kwonlycount]
+
+    is_method = pos_names and pos_names[0] in ("self", "cls")
+
+    pos_checks = []
+    kw_checks = []
+    for i, name in enumerate(pos_names):
+        if name not in hints or (i == 0 and is_method):
+            continue
+        pos_checks.append((i, name, hints[name]))
+
+    kw_checks = [(name, hints[name]) for name in kwonly_names if name in hints]
+
+    @wraps(fx)
     def wrapper(*args, **kwargs):
-        try:
-            return validated_fn(*args, **kwargs)
-        except BeartypeCallHintViolation as e:
-            raise InvalidInputError(str(e)) from None
+        _validate_call(pos_checks, kw_checks, args, kwargs)
+
+        result = fx(*args, **kwargs)
+
+        # Validate return type (skip if unannotated)
+        if ret_type is not None:
+            result = _validate_type(result, ret_type, name=f"Return of {fx.__name__!r}")
+        return result
 
     return wrapper

--- a/src/yasbd/utils/input_validator.py
+++ b/src/yasbd/utils/input_validator.py
@@ -35,10 +35,7 @@ def _validate_type(value, expected_type, name):
     if expected_type is None or expected_type is type(None):
         valid = value is None
     elif isinstance(expected_type, type):
-        if isinstance(value, type):
-            valid = issubclass(value, expected_type)
-        else:
-            valid = isinstance(value, expected_type)
+        valid = isinstance(value, expected_type)
     else:
         origin = typing.get_origin(expected_type)
         if origin is UnionType or origin is typing.Union:
@@ -50,6 +47,9 @@ def _validate_type(value, expected_type, name):
                     break
                 except InvalidInputError:
                     continue
+        elif origin is type:
+            args = typing.get_args(expected_type)
+            valid = isinstance(value, type) and (not args or issubclass(value, args[0]))
         elif origin is not None:
             valid = isinstance(value, origin)
         else:

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,73 @@
+import collections.abc
+
+import pytest
+
+from yasbd.exceptions import InvalidInputError
+from yasbd.utils.input_validator import validate_input
+
+@validate_input
+def identity(value: int) -> int:
+    return value
+
+
+@validate_input
+def union(value: int | str) -> int | str:
+    return value
+
+
+@validate_input
+def callable_(value: collections.abc.Callable) -> object:
+    return value()
+
+
+@validate_input
+def class_(value: type) -> str:
+    return value.__name__
+
+
+@pytest.mark.parametrize(
+    "func, value, expected",
+    [
+        (identity, 42, 42),
+        (union, 42, 42),
+        (union, "hello", "hello"),
+        (callable_, lambda: 42, 42),
+        (class_, str, "str"),
+    ],
+)
+def test_valid_types(func, value, expected):
+    """Test that valid inputs pass through unchanged."""
+    assert func(value) == expected
+
+
+@pytest.mark.parametrize(
+    "func, value",
+    [
+        (identity, "42"),
+        (union, 42.5),
+        (callable_, 42),
+        (class_, "str"),
+    ],
+)
+def test_invalid_types(func, value):
+    """Test that invalid inputs raise TypeError."""
+    with pytest.raises(TypeError):
+        func(value)
+
+
+def test_issubclass():
+    """Test that class objects validate via issubclass."""
+    class Animal:
+        pass
+
+    class Dog(Animal):
+        pass
+
+    @validate_input
+    def accepts_animal(value: type[Animal]) -> str:
+        return value.__name__
+
+    assert accepts_animal(Dog) == "Dog"
+
+    with pytest.raises(InvalidInputError):
+        accepts_animal(str)


### PR DESCRIPTION
## Objective

Remove the `beartype` dependency by replacing it with a partial stdlib validator, continuing the dependency trim (loguru #317, numpy/py3langid #256).

## Changes

- Replace `beartype` with a manual validator in `src/yasbd/utils/input_validator.py` covering plain types, `None`, unions (`X | Y`), and subscripted generics via origin (e.g. `Collection[str]` checks `collections.abc.Collection`; `type[X]` checks `issubclass`). Exotic forms pass through unchecked; documented in the module docstring.
- Remove `beartype>=0.22,<0.23` from `pyproject.toml` dependencies.
- Add `tests/test_input_validation.py` with 10 cases (valid passthrough, invalid raises, `type[X]` subclass checks, callables).
- Update `CHANGELOG.md` Unreleased with `Changed` entry.

### Types of change

- [ ] New feature (language support, new utility, etc.)
- [ ] Bug fix (non-breaking change fixing an issue)
- [x] Code quality / performance improvement
- [ ] Documentation update
- [ ] Other (please describe):

## Verification

- [x] I ran `pytest` and all tests pass.
- [x] I ran `ruff format . && ruff check --fix .`.
- [x] I have added tests for my changes (if applicable).
- [x] My changes don't require documentation updates, or I've updated them.